### PR TITLE
fix: two crashing identifiers, and a CI gate that would have caught them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Biome check (format + lint)
         run: bunx biome ci .
 
+      - name: Undefined identifiers (svelte-check crash class)
+        run: bun run check:undefined-names
+
       - name: Unit tests
         run: bun test src/lib src/constants --path-ignore-patterns='**/*.store.test.ts' --path-ignore-patterns='**/*.component.test.ts' --reporter=junit --reporter-outfile=junit-unit.xml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.20.1](https://github.com/uplbtools/room-tba/compare/v2.20.0...v2.20.1) (2026-08-15)
+
+
+### Bug Fixes
+
+* **map:** import map view store ([973fc24](https://github.com/uplbtools/room-tba/commit/973fc24b84e66a0644c582f5424cbbd973ac8a34))
+
 ## [2.19.3](https://github.com/uplbtools/room-tba/compare/v2.19.2...v2.19.3) (2026-08-13)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.19.3](https://github.com/uplbtools/room-tba/compare/v2.19.2...v2.19.3) (2026-08-13)
+
+
+### Bug Fixes
+
+* **map:** measure-route legibility, mode-aware snapping, visible route line ([a7893ad](https://github.com/uplbtools/room-tba/commit/a7893aded2dc8f371e613d62557f3b051d8ea6ec))
+
 ## [2.19.1](https://github.com/uplbtools/room-tba/compare/v2.19.0...v2.19.1) (2026-08-12)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@
 
 * **map:** import map view store ([973fc24](https://github.com/uplbtools/room-tba/commit/973fc24b84e66a0644c582f5424cbbd973ac8a34))
 
+# [2.20.0](https://github.com/uplbtools/room-tba/compare/v2.19.3...v2.20.0) (2026-08-13)
+
+
+### Bug Fixes
+
+* **planner:** auto-load more sections on scroll; count courses in the note ([71bb91a](https://github.com/uplbtools/room-tba/commit/71bb91a6ce0b60d2af225e13745164dcf463a721))
+
+
+### Features
+
+* **map:** camera debug mode via right-click menu ([#964](https://github.com/uplbtools/room-tba/issues/964)) ([405afa9](https://github.com/uplbtools/room-tba/commit/405afa9c136557f8ac9a2181507617d61db8a44c))
+
 ## [2.19.3](https://github.com/uplbtools/room-tba/compare/v2.19.2...v2.19.3) (2026-08-13)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 
 * **map:** measure-route legibility, mode-aware snapping, visible route line ([a7893ad](https://github.com/uplbtools/room-tba/commit/a7893aded2dc8f371e613d62557f3b051d8ea6ec))
 
+## [2.19.2](https://github.com/uplbtools/room-tba/compare/v2.19.1...v2.19.2) (2026-08-13)
+
+
+### Bug Fixes
+
+* **map-chrome:** keep the map tools panel within the viewport ([37f2579](https://github.com/uplbtools/room-tba/commit/37f2579ef7cac64d54021a5d39c9ca7cd846937c))
+* **map:** restore vector basemap on MapLibre 6 (?worker&url) ([13e7cbc](https://github.com/uplbtools/room-tba/commit/13e7cbc8c5bd88e8793146fac6c8c97e72063555)), closes [#1003](https://github.com/uplbtools/room-tba/issues/1003)
+
 ## [2.19.1](https://github.com/uplbtools/room-tba/compare/v2.19.0...v2.19.1) (2026-08-12)
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "astro-room",
   "type": "module",
-  "version": "2.19.1",
+  "version": "2.19.3",
   "packageManager": "bun@1.3.14",
   "license": "MIT",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "astro-room",
   "type": "module",
-  "version": "2.19.3",
+  "version": "2.20.1",
   "packageManager": "bun@1.3.14",
   "license": "MIT",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "serve:e2e": "bash scripts/serve-e2e.sh",
     "astro": "astro",
     "lint": "biome check .",
+    "check:undefined-names": "bun run scripts/check-undefined-names.ts",
     "lint:fix": "biome check --write --unsafe .",
     "format": "biome format --write .",
     "test": "bun test src/lib src/constants scripts/lib --path-ignore-patterns='**/*.store.test.ts' --path-ignore-patterns='**/*.component.test.ts'",

--- a/scripts/check-undefined-names.ts
+++ b/scripts/check-undefined-names.ts
@@ -1,0 +1,49 @@
+/**
+ * Fail the build on identifiers that resolve to nothing.
+ *
+ * v2.20.0 shipped a map page that threw on load: `Entry.svelte` used
+ * `mapViewStore` without importing it. `bun run build`, the unit suite, and the
+ * component tests all passed, because Svelte templates are not type-checked and
+ * no test renders the app root. `svelte-check` catches exactly this, so this
+ * script runs it and fails on the one diagnostic that always means a runtime
+ * crash: "Cannot find name".
+ *
+ * ponytail: the repo has ~1.3k other svelte-check errors (implicit any, index
+ * signatures). Gating on all of them means a cleanup nobody has time for, so
+ * this greps the crash-class subset only. Widen the filter when the rest are
+ * fixed.
+ */
+
+const CRASH_DIAGNOSTIC = /Cannot find name|Cannot find namespace/;
+
+const proc = Bun.spawn(
+  ["bunx", "svelte-check", "--threshold", "error", "--output", "human"],
+  { stdout: "pipe", stderr: "pipe" },
+);
+const [stdout, stderr] = await Promise.all([
+  new Response(proc.stdout).text(),
+  new Response(proc.stderr).text(),
+]);
+await proc.exited;
+
+const lines = `${stdout}\n${stderr}`.split("\n");
+// svelte-check prints the location line, then the diagnostic on the next line.
+const findings: string[] = [];
+lines.forEach((line, i) => {
+  if (!CRASH_DIAGNOSTIC.test(line)) return;
+  const location = (lines[i - 1] ?? "").trim().replace(`${process.cwd()}/`, "");
+  findings.push(`${location}\n  ${line.trim()}`);
+});
+
+if (findings.length > 0) {
+  console.error(
+    `\nFound ${findings.length} identifier(s) that resolve to nothing:\n`,
+  );
+  for (const finding of findings) console.error(`${finding}\n`);
+  console.error(
+    "Each one throws at runtime when that code path executes. Import the name, or delete the dead reference.\n",
+  );
+  process.exit(1);
+}
+
+console.log("No undefined identifiers.");

--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -26,6 +26,7 @@
     sidebarStore,
     announcementsStore,
   } from "@lib/store.svelte";
+  import { isRecentSearch } from "@lib/locStorage";
   import { decodeSharePlan } from "@lib/planner/share-codec";
   import { resolveSharedPlan } from "@lib/planner/import-shared";
   import Modal from "@ui/modal/Modal.svelte";

--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -383,7 +383,7 @@
   const EXTERNAL_CAMPUSES_MARKER_LAYER_ID = "external-campuses-markers";
   const EXTERNAL_CAMPUSES_LABELS_LAYER_ID = "external-campuses-labels";
   let activeRouteId = $state<string | null>(null);
-  let activeRouteStops = $state<DisplayJeepneyRoute["stops"]>([]);
+  let activeRouteStops = $state<JeepneyRoute["stops"]>([]);
   let activeRouteColor = $state<string>("#dc2626");
   let terrainModeWasEnabled = false;
   let selectedEditKey = $state<string | null>(null);

--- a/src/components/svelte/PWAInstallPrompt.svelte
+++ b/src/components/svelte/PWAInstallPrompt.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from "svelte";
+  import type { BeforeInstallPromptEvent } from "@lib/types";
   import { toastStore } from "@lib/store.svelte";
   import Download from "@lucide/svelte/icons/download";
   import X from "@lucide/svelte/icons/x";

--- a/src/components/svelte/controls/DivisionResult.svelte
+++ b/src/components/svelte/controls/DivisionResult.svelte
@@ -437,7 +437,7 @@
             disabled={savingField !== null}
             fieldSaving={savingField === "divisionName"}
             unchanged={nameDraft.trim() === division.divisionName}
-            onsave={() => saveField("divisionName")}
+            onsave={submitAllChanges}
           >
             {#snippet control()}
               <input
@@ -469,7 +469,7 @@
             disabled={savingField !== null}
             fieldSaving={savingField === "collegeId"}
             unchanged={collegeDraft === String(division.collegeId ?? "")}
-            onsave={() => saveField("collegeId")}
+            onsave={submitAllChanges}
           >
             {#snippet control()}
               <select

--- a/src/components/svelte/editor/ProposalPinPreview.svelte
+++ b/src/components/svelte/editor/ProposalPinPreview.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { MapLibre, Marker } from "svelte-maplibre";
-  import type { StyleSpecification } from "maplibre-gl";
+  import type { MapLibreMap, StyleSpecification } from "maplibre-gl";
   import { loadCampusMapStyle } from "@lib/maptiler-key";
   import {
     pinChangeBounds,
@@ -17,7 +17,7 @@
 
   let mapStyle = $state<StyleSpecification | null>(null);
   let styleError = $state(false);
-  let map = $state.raw<maplibregl.Map | null>(null);
+  let map = $state.raw<MapLibreMap | null>(null);
 
   const distance = $derived(pinMoveDistanceMeters(change));
 

--- a/src/components/svelte/modal/LandingModal.svelte
+++ b/src/components/svelte/modal/LandingModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { modalStore } from "@lib/store.svelte";
+  import type { BeforeInstallPromptEvent } from "@lib/types";
   import { designers } from "@constants/contributors";
   import {
     UPLB_TOOLS_URL,
@@ -53,7 +54,7 @@
     { id: "campus", label: "Campus team" },
   ];
 
-  function toAvatarPeople(list: typeof contributors) {
+  function toAvatarPeople(list: typeof designers) {
     return list.map((person) => ({
       name: person.name,
       href: person.href,

--- a/src/lib/stores/index.svelte.ts
+++ b/src/lib/stores/index.svelte.ts
@@ -5,6 +5,7 @@ import { describeLocationFix } from "@lib/geolocation";
 import { campusTransit } from "../../campus.config";
 import { getJSONFetch, getLocalRoomByCode } from "../local/data/utils.js";
 import type { BuildingTypeFilter } from "@constants/building-types";
+import type { ClassMapValue } from "@lib/types";
 import type { RouteTotals } from "../campus-route.js";
 import { orderDayStops, type Weekday } from "../schedule-import/day-stops.js";
 import { matchImportedScheduleRows } from "../schedule-import/match-classes.js";

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -195,3 +195,9 @@ type EntityLoadResult<T> = {
   rows: T[];
   source: "remote" | "cache";
 };
+
+/** Chromium-only `beforeinstallprompt` event; absent from TypeScript's DOM lib. */
+export type BeforeInstallPromptEvent = Event & {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: string }>;
+};


### PR DESCRIPTION
## Why

v2.20.0 shipped a map page that threw on load: `Entry.svelte` used `mapViewStore` without importing it (my miss in #1027, fixed by @klnwlks in v2.20.1). Everything I ran passed, and none of it could have caught this: Svelte templates are not type-checked, and no test renders the app root.

I reproduced it to confirm the gap is real, not carelessness: with the import removed, `bun run build` exits 0 and never mentions it.

## The gate

`svelte-check` flags it exactly (`Entry.svelte:466 Cannot find name 'mapViewStore'`). The repo has ~1,332 svelte-check errors overall, so gating on all of them means a cleanup nobody has time for. The `Cannot find name` / `Cannot find namespace` subset was only **10**, and that subset always means a runtime throw.

`scripts/check-undefined-names.ts` runs svelte-check and fails on that subset only, wired into CI next to Biome. Verified both directions: passes on this branch, and fails with a clear message when the v2.20.0 bug is reintroduced.

## Two live bugs it surfaced

- **Recent searches never persisted.** `Entry.svelte` called `isRecentSearch()` without importing it from `@lib/locStorage`. The call sits inside a `try/catch` that resets the list, so every visitor silently lost their recent searches on every page load. Silent because the catch swallowed it.
- **Divisions could not be saved in the editor.** `DivisionResult.svelte` wired both save buttons to `saveField()`, which exists in the Room/Building/Dorm siblings but was never written here, so clicking save threw. `EntityEditorField` binds `onclick={onsave}`, so the break was on every click. Both now call `submitAllChanges`, the component's own patch function that was sitting unreferenced at line 212. Note: it sets `savingField = "divisionName"` as its own fallback spinner, so saving the college field briefly spins the name field. Existing behavior of that function, left alone.

The remaining eight were dangling type names (`ClassMapValue`, `JeepneyRoute["stops"]`, the `maplibregl` namespace, `BeforeInstallPromptEvent`, and a typo'd `typeof contributors` that meant `typeof designers`).

## Verify

`bun run lint` clean, `bun run test` 871 pass, `bun run test:components` 323 pass, `bun run check:undefined-names` passes. Local `bun run build` not run: I worked in a git worktree whose symlinked `node_modules` mangles Astro's paths, so I am relying on CI's build here rather than claiming a green I did not get.

Batch into the next release; no solo release.