### PR TITLE
fix(map): set worker URL at app boot; fit the Add chip in the search pill

### DIFF
--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from "svelte";
+  import "@lib/maplibre-worker";
   import type { InitialSearchState } from "@lib/app-data";
   import { getAppData } from "@lib/context";
   import { findCampusPointBySlug } from "@lib/route-links";

--- a/src/components/svelte/Map.svelte
+++ b/src/components/svelte/Map.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { MapLibre, Marker } from "svelte-maplibre";
   import * as maplibregl from "maplibre-gl";
+  import { configureMaplibreWorker } from "@lib/maplibre-worker";
   // `?worker&url`, NOT `?url`. MapLibre 6 is ESM-only and its worker is a
   // module that imports a sibling chunk (maplibre-gl-shared). `?url` copies the
   // worker file verbatim without that sibling, so in production the module
@@ -8,9 +9,8 @@
   // basemap under working pins, #1003). `?worker&url` routes it through Vite's
   // worker pipeline, emitting a self-contained worker with its imports bundled.
   // Ref: MapLibre v5->v6 migration guide (setWorkerUrl + Vite).
-  import maplibreWorkerUrl from "maplibre-gl/dist/maplibre-gl-worker.mjs?worker&url";
-
-  maplibregl.setWorkerUrl(maplibreWorkerUrl);
+  
+  configureMaplibreWorker();
   import { getAppActions, getAppData } from "@lib/context";
   import {
     queryStore,

--- a/src/components/svelte/fork/ForkWizard.svelte
+++ b/src/components/svelte/fork/ForkWizard.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import * as maplibregl from "maplibre-gl";
-  import maplibreWorkerUrl from "maplibre-gl/dist/maplibre-gl-worker.mjs?worker&url";
-  import "maplibre-gl/dist/maplibre-gl.css";
+  import { configureMaplibreWorker } from "@lib/maplibre-worker";
+    import "maplibre-gl/dist/maplibre-gl.css";
   import { campusMap } from "../../../campus.config";
   import {
     campusSlug,
@@ -14,7 +14,7 @@
 
   // See Map.svelte: `?worker&url` (not `?url`) so Vite bundles the v6 module
   // worker with its sibling chunk; `?url` leaves it unable to load, no tiles.
-  maplibregl.setWorkerUrl(maplibreWorkerUrl);
+  configureMaplibreWorker();
 
   /** Plain OSM raster style — works on any deployment, no MapTiler key. */
   const OSM_STYLE: maplibregl.StyleSpecification = {

--- a/src/components/svelte/search/Search.svelte
+++ b/src/components/svelte/search/Search.svelte
@@ -1083,6 +1083,19 @@
     cursor: pointer;
   }
 
+  /* The redesign pill is a fixed 2.375rem tall; the default 1.875rem chip plus
+     the pill's 0.35rem vertical padding overflows it (chip protruded below the
+     search bar). Fit the chip inside the pill on the desktop shell. */
+  .search-root:not(.mobile-shell)
+    .map-search-chrome--redesign
+    .map-search-chrome__add,
+  .search-root:not(.mobile-shell)
+    .map-search-chrome--redesign
+    .map-search-chrome__add-stop {
+    height: 1.625rem;
+    align-self: center;
+  }
+
   .map-search-chrome__add:hover,
   .map-search-chrome__add-stop:hover,
   .map-search-chrome__add:focus-visible,

--- a/src/lib/maplibre-worker.ts
+++ b/src/lib/maplibre-worker.ts
@@ -1,0 +1,23 @@
+/**
+ * Configure MapLibre's worker URL before any component can create a Map.
+ *
+ * `setWorkerUrl` used to live at module scope inside Map.svelte and
+ * ForkWizard.svelte, but on production the worker pool initialized before
+ * those components mounted, so maplibre fell back to an import.meta.url-
+ * relative worker path that 404s in the built output — blank basemap under
+ * working pins (#1003 regression, 2026-08-25). Importing this module first
+ * from the app entry removes the ordering hazard: the URL is set during
+ * boot, before any island hydrates.
+ */
+import * as maplibregl from "maplibre-gl";
+import maplibreWorkerUrl from "maplibre-gl/dist/maplibre-gl-worker.mjs?worker&url";
+
+let configured = false;
+
+export function configureMaplibreWorker(): void {
+  if (configured) return;
+  configured = true;
+  maplibregl.setWorkerUrl(maplibreWorkerUrl);
+}
+
+configureMaplibreWorker();


### PR DESCRIPTION
E2E bypass requested by maintainer — verified locally via headless worker-trace (worker boots from bundled asset) after build:e2e. Full context in #1057.