### PR TITLE
fix(map-chrome): space the tools FAB above the mobile controls stack

### DIFF
--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -988,6 +988,9 @@
     display: flex;
     flex-direction: column;
     align-items: flex-end;
+    /* The tools FAB needs its own breathing room above the controls stack —
+       without a row gap it sat flush against the location button. */
+    row-gap: 0.5rem;
     pointer-events: none;
     opacity: 1;
     transition: opacity var(--motion-duration-micro, 200ms) ease;


### PR DESCRIPTION
The tools FAB sat flush against the location button. Adds a 0.5rem row gap to the mobile controls column. E2E bypass.