### PR TITLE
release: staging to main — MapTiler key on prod + mobile controls gap

### DIFF
--- a/src/components/svelte/Entry.svelte
+++ b/src/components/svelte/Entry.svelte
@@ -988,6 +988,9 @@
     display: flex;
     flex-direction: column;
     align-items: flex-end;
+    /* The tools FAB needs its own breathing room above the controls stack —
+       without a row gap it sat flush against the location button. */
+    row-gap: 0.5rem;
     pointer-events: none;
     opacity: 1;
     transition: opacity var(--motion-duration-micro, 200ms) ease;


### PR DESCRIPTION
Two fixes ride this release: (1) PUBLIC_MAPTILER_KEY was never set on Vercel Production (Preview only, 13 days) — every prod build shipped keyless and ran the OpenFreeMap fallback; the var is now on Production, this rebuild picks it up. (2) 0.5rem gap between the mobile tools FAB and the controls stack (#1069). E2E bypass per maintainer.