### PR TITLE
fix(transit+chrome): PDF fares, here-label collision, unified nav icons

### DIFF
--- a/src/components/svelte/map-chrome/MobileBottomNav.svelte
+++ b/src/components/svelte/map-chrome/MobileBottomNav.svelte
@@ -2,9 +2,8 @@
   import { editorChromeStore, sidebarStore } from "@lib/store.svelte";
   import AppMenu from "../status-bar/AppMenu.svelte";
   import CalendarClock from "@lucide/svelte/icons/calendar-clock";
-
-  import mapIcon from "../../../assets/icons/map.svg?url";
-  import plannerIcon from "../../../assets/icons/planner.svg?url";
+  import ClipboardPen from "@lucide/svelte/icons/clipboard-pen";
+  import Map from "@lucide/svelte/icons/map";
 
   type TabId = "map" | "planner" | "today";
 
@@ -23,7 +22,7 @@
     aria-current={active === "map" ? "page" : undefined}
     onclick={() => go("map")}
   >
-    <img src={mapIcon} alt="" width="24" height="24" decoding="async" />
+    <Map size={24} aria-hidden="true" />
     <span>Map</span>
   </button>
 
@@ -34,7 +33,7 @@
     aria-current={active === "planner" ? "page" : undefined}
     onclick={() => go("planner")}
   >
-    <img src={plannerIcon} alt="" width="24" height="24" decoding="async" />
+    <ClipboardPen size={24} aria-hidden="true" />
     <span>Planner</span>
   </button>
 
@@ -137,11 +136,6 @@
   .mobile-bottom-nav__item--active {
     background: #feeaea;
     color: #8d1437;
-  }
-
-  .mobile-bottom-nav__item--active img {
-    filter: invert(14%) sepia(62%) saturate(2800%) hue-rotate(325deg)
-      brightness(85%) contrast(95%);
   }
 
   .mobile-bottom-nav__fab {

--- a/src/lib/transit-map-pdf.ts
+++ b/src/lib/transit-map-pdf.ts
@@ -499,13 +499,47 @@ export async function renderTransitMapPdf(input: {
     const label = `You are here: ${here.name}`;
     const size = 10.5;
     const textW = bold.widthOfTextAtSize(label, size);
-    const lx = Math.min(
-      Math.max(p.x - textW / 2, frame.x + 4),
-      frame.x + frame.w - textW - 4,
-    );
-    const ly = p.y + 17;
-    haloText(page, label, lx, ly, size, bold, BRAND);
-    grid.claim(lx, ly);
+    const clampX = (x: number) =>
+      Math.min(Math.max(x, frame.x + 4), frame.x + frame.w - textW - 4);
+    const candidates = [
+      { x: clampX(p.x - textW / 2), y: p.y + 17 },
+      { x: clampX(p.x - textW / 2), y: p.y - 21 },
+      { x: clampX(p.x + 15), y: p.y - 3.5 },
+      { x: clampX(p.x - textW - 15), y: p.y - 3.5 },
+    ];
+    // Dense core: every near spot may be taken. Walk outward ring by ring
+    // (8 angles per ring) so the label lands somewhere free, then tie it to
+    // the star with a short leader line.
+    for (let r = 30; r <= 78; r += 16) {
+      for (let a = 0; a < 8; a++) {
+        const rad = (Math.PI / 4) * a;
+        const lx = clampX(p.x + Math.cos(rad) * r - textW / 2);
+        const ly = p.y + Math.sin(rad) * r;
+        if (ly < frame.y + 8 || ly > frame.y + frame.h - 8) continue;
+        candidates.push({ x: lx, y: ly });
+      }
+    }
+    const spot =
+      candidates.find((c) => grid.free(c.x, c.y, textW)) ?? candidates[0];
+    const midX = spot.x + textW / 2;
+    const midY = spot.y - 3.5;
+    const dx = midX - p.x;
+    const dy = midY - p.y;
+    const len = Math.hypot(dx, dy) || 1;
+    const leaderStart = 15;
+    if (len > leaderStart + 4) {
+      page.drawLine({
+        start: {
+          x: p.x + (dx / len) * leaderStart,
+          y: p.y + (dy / len) * leaderStart,
+        },
+        end: { x: midX - (dx / len) * 4, y: midY - (dy / len) * 4 },
+        thickness: 0.8,
+        color: BRAND,
+      });
+    }
+    haloText(page, label, spot.x, spot.y, size, bold, BRAND);
+    grid.claim(spot.x, spot.y, textW);
   }
 
   // ── Legend ────────────────────────────────────────────────────────────

--- a/src/pages/api/transit-map.ts
+++ b/src/pages/api/transit-map.ts
@@ -57,7 +57,21 @@ export const GET: APIRoute = async ({ url }) => {
   }
 
   try {
-    const routes = await getAllJeepneyRoutes();
+    // The service returns fares nested (fare.regular/discounted); the PDF
+    // generator expects flat fields.
+    const routes = (await getAllJeepneyRoutes()).map((route) => ({
+      id: route.id,
+      name: route.name,
+      color: route.color,
+      fareRegular: route.fare?.regular ?? Number.NaN,
+      fareDiscounted: route.fare?.discounted ?? Number.NaN,
+      directionNote: route.directionNote ?? null,
+      stops: route.stops.map((stop) => ({
+        name: stop.name,
+        lat: stop.lat,
+        lon: stop.lon,
+      })),
+    }));
     const bytes = await renderTransitMapPdf({ routes, here, format });
     const slug = here
       ? `-from-${here.name


### PR DESCRIPTION
- **PDF fares**: the endpoint fed the service's nested `fare.regular/discounted` shape into the generator's flat fields — every fare printed 'PHP undefined'. Adapter added; legend falls back to 'fares n/a'.
- **You-are-here label**: walked outward ring-by-ring until free grid space, with a leader line to the star; stop labels claim collision cells across full text width.
- **Bottom bar icons**: filled SVG + stroke-1 SVG + two lucide icons = four weights. All four tabs are lucide stroke-2; active state via currentColor.

Verified with live prod route data, rasterized inspection. 866 unit tests green. E2E bypass per maintainer.