### PR TITLE
docs: set payout methods to GCash and QR Ph

### DIFF
--- a/docs/funding-model.md
+++ b/docs/funding-model.md
@@ -28,7 +28,7 @@ reports:
 
 Minimum **5 points/month** to receive a payout for that month.
 
-**Payment methods:** TBD — GCash, bank transfer.
+**Payment methods:** GCash and QR Ph.
 
 ## Sponsor tiers
 


### PR DESCRIPTION
Replaces the TBD payout methods line in docs/funding-model.md with the decided methods: GCash and QR Ph. Requested by maintainer.