### PR TITLE
docs: formalize financial transparency policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,13 @@ Room TBA is funded by curated campus-relevant sponsors and one-time donations. R
 
 **[Donate](https://room-tba.uplb.tools/donate)** · **[Become a sponsor](https://room-tba.uplb.tools/sponsors)** · [Funding model](docs/funding-model.md) · [Ad policy](docs/ad-policy.md)
 
+**Transparency policy:**
+
+- Donations are anonymous by default. The app stores only the amount and an optional message, never donor identity. Donors who want public credit can ask on Discord or Messenger.
+- We publish a transparency report (totals received, itemized expenses, payout status, running balance) instead of raw transaction slips, which carry donor and account details.
+- Original PayMongo and GCash records are retained privately as the audit trail. Redacted copies are available on request. Expense receipts (hosting, domain) may be published with personal details cropped.
+- Contributor payouts are made via GCash and QR Ph, points-based per the [funding model](docs/funding-model.md).
+
 ---
 
 ## Fork this for your campus

--- a/docs/funding-model.md
+++ b/docs/funding-model.md
@@ -51,6 +51,18 @@ Checkout Session (QR Ph). The API route (`/api/donate`) needs
 `PAYMONGO_SECRET_KEY` set on Vercel; without it the page shows a
 not-configured error. Donations follow the same 40/30/30 split.
 
+## Transparency
+
+- **Anonymous by default.** `/donate` stores only the amount and an optional
+  message. Donor identity never reaches the app; PayMongo processes the
+  payment. Donors who want public credit can ask via Discord or Messenger.
+- **Ledger over slips.** We publish a transparency report: totals received,
+  itemized expenses, payout status, running balance. Raw transaction slips
+  are not published; they carry donor and account details and reference IDs.
+- **Audit trail.** Original PayMongo and GCash records are retained
+  privately. Redacted copies are available on request. Expense receipts
+  (hosting, domain renewals) may be published with personal details cropped.
+
 ## Impression guarantee
 
 - **Gold:** minimum 3,000 impressions/month


### PR DESCRIPTION
Formalizes the financial transparency system in the README (Sponsors section) and docs/funding-model.md (new Transparency section):

- Donations anonymous by default; only amount + optional message stored; opt-in public credit.
- Transparency report (ledger) published instead of raw transaction slips, which carry donor and account details.
- Original PayMongo/GCash records retained privately as audit trail; redacted copies on request; expense receipts publishable with personal details cropped.
- Contributor payouts via GCash and QR Ph (follows #1075).