### PR TITLE
release: August Vercel platform invoice on transparency page

### DIFF
--- a/src/pages/transparency.astro
+++ b/src/pages/transparency.astro
@@ -35,11 +35,11 @@ import SiteFooter from "../components/SiteFooter.astro";
         </div>
         <div class="summary-item">
           <span class="summary-label">Expenses</span>
-          <span class="summary-value">₱2,198.33</span>
+          <span class="summary-value">₱4,978.17</span>
         </div>
         <div class="summary-item summary-net">
           <span class="summary-label">Net</span>
-          <span class="summary-value">−₱407.98</span>
+          <span class="summary-value">−₱3,187.82</span>
         </div>
       </div>
 
@@ -87,9 +87,19 @@ import SiteFooter from "../components/SiteFooter.astro";
           </div>
           <div class="ledger-amount">₱316.03 ($5.00)</div>
         </li>
+        <li>
+          <div class="ledger-what">
+            Vercel platform and usage, invoice 67F77D49-0006, issued Aug 22.
+            Pro seat ₱1,264.14 ($20.00), build minutes ₱836.86 ($13.24),
+            observability ₱324.25 ($5.13), serverless compute ₱185.83 ($2.94),
+            bandwidth ₱67.63 ($1.07), web analytics ₱53.09 ($0.84), functions
+            and image tools ₱48.04 ($0.76)
+          </div>
+          <div class="ledger-amount">₱2,779.84 ($43.98)</div>
+        </li>
         <li class="ledger-total">
           <div class="ledger-what">Total out</div>
-          <div class="ledger-amount">₱2,198.33</div>
+          <div class="ledger-amount">₱4,978.17</div>
         </li>
       </ul>
 
@@ -136,17 +146,19 @@ import SiteFooter from "../components/SiteFooter.astro";
 
       <h3>Notes</h3>
       <p>
-        The maintainers covered the ₱407.98 gap out of pocket. All 13 site
-        donations came in during enlistment week (Aug 3 to 9) and none after.
-        Donations follow campus foot traffic.
+        Donations covered ₱1,790.35 of the month's ₱4,978.17 in costs. The
+        rest falls to the maintainers. All 13 site donations came in during
+        enlistment week (Aug 3 to 9) and none after. Donations follow campus
+        foot traffic.
       </p>
       <p>
         The OpenCode receipt shows the real card charge of ₱316.03 at 63.2069
         pesos per dollar. The Vercel and Porkbun peso figures use that same
         rate, since all three were paid on the same card in the same period.
         The domain was charged Jul 13 and is counted here because this is the
-        first report. From September on, expenses count in the month the card
-        was charged.
+        first report. The August platform invoice is counted in the month it
+        was issued. From September on, each report covers the invoices and
+        charges dated that month.
       </p>
       <p>
         No contributor payouts this month. Income was below the operating


### PR DESCRIPTION
Adds invoice 67F77D49-0006 (.98) to the August ledger with the per-product breakdown, updates totals and method notes.

https://claude.ai/code/session_01T3dKAgr7Yo2637teHP4vNU