### PR TITLE
release: reimbursement note on transparency report

### DIFF
--- a/src/pages/transparency.astro
+++ b/src/pages/transparency.astro
@@ -166,7 +166,8 @@ import SiteFooter from "../components/SiteFooter.astro";
       <h3>Notes</h3>
       <p>
         Donations covered ₱1,790.35 of the period's ₱5,985.03 in costs. The
-        rest falls to the maintainers. All 13 site donations came in during
+        maintainers carry the ₱4,194.68 shortfall for now. Future donations
+        reimburse them before anything else, then follow the 40/30/30 split. All 13 site donations came in during
         enlistment week (Aug 3 to 9) and none after. Donations follow campus
         foot traffic.
       </p>


### PR DESCRIPTION
States that future donations reimburse the maintainers' shortfall before the 40/30/30 split.

https://claude.ai/code/session_01T3dKAgr7Yo2637teHP4vNU