### PR TITLE
release: liabilities section on transparency report

### DIFF
--- a/src/pages/transparency.astro
+++ b/src/pages/transparency.astro
@@ -121,6 +121,31 @@ import SiteFooter from "../components/SiteFooter.astro";
         </li>
       </ul>
 
+      <h3>Liabilities</h3>
+      <p class="ledger-intro">
+        Every expense above was paid from the maintainer's personal card. What
+        donations did not cover, the project owes back.
+      </p>
+      <ul class="ledger">
+        <li>
+          <div class="ledger-what">
+            Owed to the maintainer, expenses of ₱5,985.03 less ₱1,790.35 in
+            donations received
+          </div>
+          <div class="ledger-amount">₱4,194.68</div>
+        </li>
+        <li>
+          <div class="ledger-what">
+            Waived by the maintainer as a personal donation
+          </div>
+          <div class="ledger-amount">−₱500.00</div>
+        </li>
+        <li class="ledger-total">
+          <div class="ledger-what">Balance owed</div>
+          <div class="ledger-amount">₱3,694.68</div>
+        </li>
+      </ul>
+
       <h3>Receipts</h3>
       <div class="receipts">
         <figure>
@@ -177,8 +202,10 @@ import SiteFooter from "../components/SiteFooter.astro";
       <h3>Notes</h3>
       <p>
         Donations covered ₱1,790.35 of the period's ₱5,985.03 in costs. The
-        maintainers carry the ₱4,194.68 shortfall for now. Future donations
-        reimburse them before anything else, then follow the 40/30/30 split. All 13 site donations came in during
+        maintainer paid the rest personally and waived ₱500.00 of it as a
+        donation, leaving the balance under Liabilities. Future donations
+        repay that balance before anything else, then follow the 40/30/30
+        split. All 13 site donations came in during
         enlistment week (Aug 3 to 9) and none after. Donations follow campus
         foot traffic.
       </p>


### PR DESCRIPTION
Tracks the balance owed to the maintainer for personally paid expenses, less a PHP 500 waiver donated back.

https://claude.ai/code/session_01T3dKAgr7Yo2637teHP4vNU