### PR TITLE
release: ad ROI note on transparency report

### DIFF
--- a/src/pages/transparency.astro
+++ b/src/pages/transparency.astro
@@ -218,6 +218,13 @@ import SiteFooter from "../components/SiteFooter.astro";
         and charges dated that month.
       </p>
       <p>
+        What the ad spend bought. The ads promoted the app during enlistment
+        week. Pageviews roughly doubled against the prior week, 30,346 versus
+        15,430 (Vercel Analytics), and all 13 site donations arrived in that
+        window, ₱1,290.35 net against ₱1,006.86 spent. Enlistment traffic
+        rises on its own, so the ads do not get full credit for the jump.
+      </p>
+      <p>
         No contributor payouts this month. Income was below the operating
         floor, so everything went to operations.
       </p>


### PR DESCRIPTION
Answers the community question about the advertising line, pageviews and donations during the ad window against the spend, with the enlistment-week caveat.

https://claude.ai/code/session_01T3dKAgr7Yo2637teHP4vNU