### PR TITLE
fix(pwa): prompt-mode SW updates stop the post-deploy boot error

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -28,7 +28,13 @@ export default defineConfig({
   integrations: [
     svelte(),
     AstroPWA({
-      registerType: "autoUpdate",
+      // "prompt" instead of "autoUpdate": an auto-updating worker seizes
+      // control of already-open pages mid-boot, their old hashed chunks miss
+      // the new precache, the fetches 404, and every cached visitor sees the
+      // boot error after each deploy. With "prompt" the old worker keeps
+      // serving its own consistent bundle until the user applies the update
+      // (StatusBar listens for pwa:need-refresh, wired in src/pwa.ts).
+      registerType: "prompt",
       workbox: {
         // AppRoot includes map + editor + PGlite; auth/proposals pushed it past 2 MiB.
         maximumFileSizeToCacheInBytes: 3 * 1024 * 1024,


### PR DESCRIPTION
Every deploy showed cached visitors the "Room TBA did not finish loading" screen. autoUpdate's skipWaiting+clientsClaim let the new worker hijack pages mid-boot; their old chunks miss the new precache and 404 since Vercel drops old build assets. Switching to prompt keeps the old worker serving its consistent bundle, and activates the already-wired StatusBar refresh flow (pwa.ts onNeedRefresh was dead code under autoUpdate).

Testing note: no automated e2e for the SW swap (needs two sequential builds under one origin); manual verification path is build:e2e, load, rebuild with a change, confirm the refresh chip appears and the old session keeps working. The Layout watchdog stays as the last-resort recovery.

https://claude.ai/code/session_01Mi29CGtSwWwztD9hS3zZZg