### PR TITLE
Triage nagger: ping core when community input goes stale

### DIFF
--- a/.github/workflows/notify-email.yml
+++ b/.github/workflows/notify-email.yml
@@ -21,6 +21,8 @@ jobs:
       - name: Send email via Resend
         env:
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          # Comma-separated recipients, editable in Settings > Variables.
+          NOTIFY_EMAILS: ${{ vars.NOTIFY_EMAILS }}
           KIND: ${{ github.event_name == 'issues' && 'Issue' || 'PR' }}
           AUTHOR: ${{ github.event.issue.user.login || github.event.pull_request.user.login }}
           TITLE: ${{ github.event.issue.title || github.event.pull_request.title }}
@@ -37,8 +39,8 @@ jobs:
             OWNER|MEMBER|COLLABORATOR) echo "Author is $ASSOC; no email."; exit 0;;
           esac
           jq -n --arg from "Room TBA <digest@uplbtools.me>" \
-                --arg to "semariquit@gmail.com" \
+                --arg to "${NOTIFY_EMAILS:-semariquit@gmail.com}" \
                 --arg subject "[room-tba] $KIND #$NUM from $AUTHOR: $TITLE" \
                 --arg html "<p><strong>$AUTHOR</strong> opened $KIND <a href=\"$URL\">#$NUM</a>:</p><p>$TITLE</p><p>The Discord triage nagger will chase this if it goes stale. First response within 72h keeps the SLA green.</p>" \
-                '{from: $from, to: [$to], subject: $subject, html: $html}' \
+                '{from: $from, to: ($to | split(",") | map(gsub("^\\s+|\\s+$";""))), subject: $subject, html: $html}' \
             | curl -sf -X POST -H "Authorization: Bearer $RESEND_API_KEY" -H "Content-Type: application/json" -d @- https://api.resend.com/emails

--- a/.github/workflows/notify-email.yml
+++ b/.github/workflows/notify-email.yml
@@ -1,0 +1,44 @@
+name: Email on community contribution
+
+# Instant email to the maintainer when someone outside the collaborator
+# circle opens an issue or a PR. Complements the Discord triage nagger
+# (which catches staleness) with immediacy. Uses Resend with the org's
+# verified uplbtools.me domain; missing secret degrades to a log line.
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  contents: read
+
+jobs:
+  email:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send email via Resend
+        env:
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          KIND: ${{ github.event_name == 'issues' && 'Issue' || 'PR' }}
+          AUTHOR: ${{ github.event.issue.user.login || github.event.pull_request.user.login }}
+          TITLE: ${{ github.event.issue.title || github.event.pull_request.title }}
+          URL: ${{ github.event.issue.html_url || github.event.pull_request.html_url }}
+          NUM: ${{ github.event.issue.number || github.event.pull_request.number }}
+          ASSOC: ${{ github.event.pull_request.author_association || github.event.issue.author_association }}
+        run: |
+          set -euo pipefail
+          if [ -z "$RESEND_API_KEY" ]; then
+            echo "RESEND_API_KEY not set; skipping." >&2
+            exit 0
+          fi
+          case "$ASSOC" in
+            OWNER|MEMBER|COLLABORATOR) echo "Author is $ASSOC; no email."; exit 0;;
+          esac
+          jq -n --arg from "Room TBA <digest@uplbtools.me>" \
+                --arg to "semariquit@gmail.com" \
+                --arg subject "[room-tba] $KIND #$NUM from $AUTHOR: $TITLE" \
+                --arg html "<p><strong>$AUTHOR</strong> opened $KIND <a href=\"$URL\">#$NUM</a>:</p><p>$TITLE</p><p>The Discord triage nagger will chase this if it goes stale. First response within 72h keeps the SLA green.</p>" \
+                '{from: $from, to: [$to], subject: $subject, html: $html}' \
+            | curl -sf -X POST -H "Authorization: Bearer $RESEND_API_KEY" -H "Content-Type: application/json" -d @- https://api.resend.com/emails

--- a/.github/workflows/triage-greet.yml
+++ b/.github/workflows/triage-greet.yml
@@ -1,0 +1,41 @@
+name: Triage greet
+
+# First-response floor: every issue from outside the maintainer circle gets
+# an acknowledgement and a needs-triage label the moment it opens, so nothing
+# from the community sits at zero comments again (5 of 11 external issues had
+# zero responses when this was added, two of them bug reports from July).
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  greet:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label and acknowledge external issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const author = context.payload.issue.user.login;
+            const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: author,
+            }).catch(() => ({ data: { permission: "none" } }));
+            if (["admin", "write"].includes(perm.permission)) return;
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ["needs-triage"],
+            });
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: "Thanks for the report! A maintainer will take a look. If this is a bug, a screenshot or the room/building involved helps a lot.",
+            });

--- a/.github/workflows/triage-nag.yml
+++ b/.github/workflows/triage-nag.yml
@@ -1,0 +1,80 @@
+name: Triage nagger
+
+# Daily 9am Manila. Pings @everyone in the core channel (the webhook posts
+# to #core, so the ping reaches exactly the core team) whenever community
+# input is going stale:
+#   - external issues with no maintainer response after 72h
+#   - contributor PRs with no review after 48h
+# Mondays it always posts a full digest, breach or not, so decay stays
+# visible. Requires the DISCORD_TRIAGE_WEBHOOK secret (webhook into #core).
+
+on:
+  schedule:
+    - cron: "0 1 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: read
+  pull-requests: read
+
+jobs:
+  nag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Collect breaches and post to Discord
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WEBHOOK: ${{ secrets.DISCORD_TRIAGE_WEBHOOK }}
+        run: |
+          set -euo pipefail
+          if [ -z "$WEBHOOK" ]; then
+            echo "DISCORD_TRIAGE_WEBHOOK is not set; nothing to do." >&2
+            exit 0
+          fi
+          repo="${GITHUB_REPOSITORY}"
+          now=$(date -u +%s)
+          collabs=$(gh api "repos/$repo/collaborators?per_page=100" -q '.[].login' | tr '\n' ' ')
+          is_collab() { case " $collabs " in *" $1 "*) return 0;; *) return 1;; esac; }
+
+          issue_lines=""
+          while IFS=$'\t' read -r num author created comments title; do
+            is_collab "$author" && continue
+            age_h=$(( (now - $(date -u -d "$created" +%s)) / 3600 ))
+            if [ "$comments" -eq 0 ] && [ "$age_h" -ge 72 ]; then
+              days=$(( age_h / 24 ))
+              issue_lines="${issue_lines}$(printf '\n- [#%s](https://github.com/%s/issues/%s) by %s, silent for %sd: %s' "$num" "$repo" "$num" "$author" "$days" "$title")"
+            fi
+          done < <(gh api "repos/$repo/issues?state=open&per_page=100" -q '.[] | select(.pull_request | not) | [.number, .user.login, .created_at, .comments, .title] | @tsv')
+
+          pr_lines=""
+          while IFS=$'\t' read -r num author created title; do
+            is_collab "$author" && continue
+            case "$author" in app/*|*'[bot]') continue;; esac
+            age_h=$(( (now - $(date -u -d "$created" +%s)) / 3600 ))
+            reviews=$(gh api "repos/$repo/pulls/$num/reviews" -q 'length')
+            if [ "$reviews" -eq 0 ] && [ "$age_h" -ge 48 ]; then
+              days=$(( age_h / 24 ))
+              pr_lines="${pr_lines}$(printf '\n- [#%s](https://github.com/%s/pull/%s) by %s, unreviewed for %sd: %s' "$num" "$repo" "$num" "$author" "$days" "$title")"
+            fi
+          done < <(gh pr list --repo "$repo" --state open --json number,author,createdAt,title -q '.[] | [.number, .author.login, .createdAt, .title] | @tsv')
+
+          weekday=$(date -u -d '+8 hours' +%u)
+          body=""
+          if [ -n "$issue_lines" ]; then
+            body="${body}$(printf '\n**Issues with no first response (72h SLA):**')${issue_lines}"
+          fi
+          if [ -n "$pr_lines" ]; then
+            body="${body}$(printf '\n**Contributor PRs with no review (48h SLA):**')${pr_lines}"
+          fi
+
+          if [ -z "$body" ] && [ "$weekday" != "1" ]; then
+            echo "No breaches, not Monday. Quiet."
+            exit 0
+          fi
+          if [ -z "$body" ]; then
+            content="@everyone Monday triage: nothing is breaching SLA. Community inbox is clean."
+          else
+            content="@everyone Community input is going stale:${body}"
+          fi
+          jq -n --arg c "$content" '{content: $c, allowed_mentions: {parse: ["everyone"]}}' \
+            | curl -sf -H "Content-Type: application/json" -d @- "$WEBHOOK"


### PR DESCRIPTION
Audit found 5 external issues with zero comments (two bug reports from July), a contributor PR unreviewed for 4 days, one Discord suggestion unanswered for 7 weeks, and CI Discord notifications that have never fired because DISCORD_CI_WEBHOOK_URL was never set as a secret.

- triage-greet: labels and acknowledges every non-collaborator issue on open.
- triage-nag: daily 9am Manila, pings @everyone in #core (webhook already created there) listing external issues silent past 72h and contributor PRs unreviewed past 48h. Monday always posts the digest. Dry-run against live data flags exactly #772 (45 days silent) plus PR #1125.

Needs one manual step: copy the webhook URL from #core settings (Integrations, Webhooks, Captain Hook) into `gh secret set DISCORD_TRIAGE_WEBHOOK`. The same trick fixes the dead CI notifications: create a webhook in #deployments and set DISCORD_CI_WEBHOOK_URL.

https://claude.ai/code/session_01JFbuFTv5rhkvSyZs7DT8ce