### PR TITLE
Boot survives deploys: skew protection and a complete precache

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -37,7 +37,11 @@ export default defineConfig({
       registerType: "prompt",
       workbox: {
         // AppRoot includes map + editor + PGlite; auth/proposals pushed it past 2 MiB.
-        maximumFileSizeToCacheInBytes: 3 * 1024 * 1024,
+        // pglite's wasm (10MB) and data (6MB) must fit: they are the boot
+        // path, and an install without them refetches from the network,
+        // where any newer deploy 404s the old hashes and boot dies (the
+        // "Room TBA did not finish loading" card).
+        maximumFileSizeToCacheInBytes: 12 * 1024 * 1024,
         // The Vercel adapter otherwise points globDirectory at dist/server,
         // so nothing client-side gets precached and the app can't load
         // offline. Glob the actual client output instead.
@@ -46,7 +50,7 @@ export default defineConfig({
         // not the ~650 entity SEO pages) so the app loads offline. The
         // navigate fallback serves that shell for offline navigations.
         globPatterns: [
-          "**/*.{js,css,ico,png,svg,webmanifest,json,jpg}",
+          "**/*.{js,css,ico,png,svg,webmanifest,json,jpg,wasm,data}",
           "index.html",
           "privacy/index.html",
           "terms/index.html",
@@ -390,6 +394,10 @@ export default defineConfig({
   adapter: e2eNodeAdapter
     ? node({ mode: "standalone" })
     : vercel({
+        // Old clients keep resolving their own deployment's hashed assets
+        // (?dpl= pinning) instead of 404ing after every release. Second
+        // layer of the boot-failure fix; the first is precaching pglite.
+        skewProtection: true,
         // Entity SEO pages use prerender=false and render on first request; Vercel
         // caches HTML at the edge (ISR). Admin writes revalidate via ISR_BYPASS_TOKEN.
         isr: {


### PR DESCRIPTION
The "Room TBA did not finish loading" card came back tonight on a good connection. Root cause: pglite's wasm and data exceed the 3MB precache cap and were never in the glob patterns, so booting clients fetch them from the network, and after any deploy the old hashes 404 and boot hangs into the watchdog card. Multiple prod deploys tonight made it visible.

- @astrojs/vercel skewProtection on, and skewProtectionMaxAge set to 48h on the project via API, old clients resolve their own deployment's assets.
- Precache cap raised to 12MB with wasm and data globbed in, installs are complete offline copies.

https://claude.ai/code/session_01JFbuFTv5rhkvSyZs7DT8ce