### PR TITLE
refactor(modal): one Dialog shell, a modal registry, and Map tools as a real dialog

### DIFF
--- a/src/components/svelte/MapToolsFlyout.svelte
+++ b/src/components/svelte/MapToolsFlyout.svelte
@@ -7,7 +7,6 @@
   // Wrench, not layers: this trigger opens a toolbox (travel time, measure
   // route, legend), and `layers` is the legend chip sitting right beside it.
   import Wrench from "@lucide/svelte/icons/wrench";
-  import { fade } from "svelte/transition";
   import {
     mapToolsStore,
     measureRouteStore,
@@ -16,7 +15,6 @@
   } from "@lib/store.svelte";
   import { sidebarStore } from "@lib/store.svelte";
   import { routableTodayWeekday, routeToday } from "@lib/today-route";
-  import { panelFadeIn, panelFadeOut } from "@lib/motion";
   import MapViewControls from "@ui/MapViewControls.svelte";
   import WaybackImageryControl from "@ui/WaybackImageryControl.svelte";
   import MapLegend from "@ui/MapLegend.svelte";
@@ -25,15 +23,11 @@
   import TrailControl from "@ui/TrailControl.svelte";
   import JeepneyMenu from "@ui/JeepneyMenu.svelte";
   import ScheduleImportPanel from "@ui/ScheduleImportPanel.svelte";
-  import { trapFocus } from "@lib/focus-trap";
   import MapChromeFabTrigger from "@ui/map-chrome/MapChromeFabTrigger.svelte";
-  import MapChromePanel from "@ui/map-chrome/MapChromePanel.svelte";
+  import Dialog from "@ui/modal/Dialog.svelte";
   import "./map-chrome/map-chrome.css";
   import { MediaQuery } from "svelte/reactivity";
 
-  let panelEl = $state<HTMLDivElement | null>(null);
-  let shellEl = $state<HTMLDivElement | null>(null);
-  const reducedMotion = new MediaQuery("(prefers-reduced-motion: reduce)");
   const mobile = new MediaQuery("max-width:48rem");
   // Transit moved to the sidebar's Jeepney routes browse panel; Map tools now
   // mirrors the Settings modal sections.
@@ -91,33 +85,6 @@
     if (measureRouteStore.active) mapToolsStore.close();
   }
 
-  $effect(() => {
-    if (!mapToolsStore.open || !panelEl) return;
-    return trapFocus(panelEl, { onEscape: () => mapToolsStore.close() });
-  });
-
-  // The desktop panel opens absolutely below the trigger, which can sit well
-  // down the screen. A plain `max-height: 75vh` is measured from the viewport
-  // top, so the panel ran off the bottom edge with no way to scroll to it.
-  // Cap it to the space that actually remains below its own top edge instead.
-  $effect(() => {
-    const el = shellEl;
-    if (!mapToolsStore.open || !el || mobile.current) return;
-    const apply = () => {
-      const top = el.getBoundingClientRect().top;
-      // Stop above the attribution strip, not the viewport edge — the strip
-      // z-stacks above the panel and was printing over its last row.
-      const attribution = document.querySelector(".map-attrib-corner");
-      const reserved = 12 + (attribution?.getBoundingClientRect().height ?? 0);
-      el.style.setProperty(
-        "--tools-panel-max-h",
-        `${Math.max(160, window.innerHeight - top - reserved)}px`,
-      );
-    };
-    apply();
-    window.addEventListener("resize", apply);
-    return () => window.removeEventListener("resize", apply);
-  });
 </script>
 
 <div class="map-tools-flyout">
@@ -130,20 +97,16 @@
     <Wrench size={18} aria-hidden="true" />
   </MapChromeFabTrigger>
 
-  {#if mapToolsStore.open}
-    <div
-      class="map-tools-panel-shell"
-      bind:this={shellEl}
-      in:fade={panelFadeIn(reducedMotion.current)}
-      out:fade={panelFadeOut(reducedMotion.current)}
-    >
-      <MapChromePanel
-        bind:element={panelEl}
-        id="map-tools-panel"
-        panelClass="map-chrome-panel map-tools-panel"
-        title="Map tools"
-        onclose={() => mapToolsStore.close()}
-      >
+  <Dialog
+    open={mapToolsStore.open}
+    onclose={() => mapToolsStore.close()}
+    size="large"
+    ariaLabel="Map tools"
+    closeLabel="Close map tools"
+  >
+    <div class="map-tools-dialog" id="map-tools-panel">
+      <h2 class="map-tools-dialog__title">Map tools</h2>
+      <div class="map-tools-dialog__body">
         {#if dayRoutable}
           <button
             type="button"
@@ -236,12 +199,55 @@
             {/if}
           </div>
         {/each}
-      </MapChromePanel>
+      </div>
     </div>
-  {/if}
+  </Dialog>
 </div>
 
 <style>
+  /* Map tools is a full dialog now, not a popover wedged under its trigger.
+     The old shell had to measure remaining viewport space and cap its own
+     height; the dialog just scrolls its body. */
+  .map-tools-dialog {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    flex: 1 1 auto;
+    padding: 0.25rem 0.25rem 0.5rem;
+  }
+
+  .map-tools-dialog__title {
+    margin: 0 2.5rem 0.75rem 0.5rem;
+    font-size: 1.125rem;
+    font-weight: 700;
+    color: hsl(0, 0%, 15%);
+  }
+
+  .map-tools-dialog__body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    min-height: 0;
+    flex: 1 1 auto;
+    overflow-y: auto;
+    padding: 0 0.5rem 0.25rem;
+  }
+
+  /* Two columns of tools on a wide dialog: the list was a single cramped
+     column even when there was room for more. */
+  @media (min-width: 48rem) {
+    .map-tools-dialog__body {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      align-content: start;
+      gap: 0.75rem 1rem;
+    }
+
+    .map-tools-dialog__body :global(.accordion-section) {
+      grid-column: 1 / -1;
+    }
+  }
+
   .map-tools-flyout {
     position: relative;
     pointer-events: auto;

--- a/src/components/svelte/modal/Dialog.svelte
+++ b/src/components/svelte/modal/Dialog.svelte
@@ -1,0 +1,213 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+  import { fade, fly } from "svelte/transition";
+  import { MediaQuery } from "svelte/reactivity";
+  import X from "@lucide/svelte/icons/x";
+  import IconButton from "@ui/IconButton.svelte";
+  import { trapFocus } from "@lib/focus-trap";
+  import {
+    modalContentDismiss,
+    modalContentReveal,
+    overlayFade,
+  } from "@lib/motion";
+
+  /**
+   * The one dialog shell. Every modal surface in the app renders through
+   * this: overlay, focus trap, escape, motion, sizing, and a single close
+   * button live here and nowhere else. Before this existed each of the
+   * fifteen modal branches hand-rolled its own close button and picked a
+   * width through a nested ternary, which is how they drifted apart.
+   *
+   * Sizes are intents, not pixel values:
+   *   compact   a short list or summary
+   *   reading   prose and forms, capped at a readable measure
+   *   default   general content
+   *   large     task surfaces (review queue, changelog)
+   *   showcase  self-chrome content that paints to the edges (landing)
+   */
+  export type DialogSize =
+    | "compact"
+    | "reading"
+    | "default"
+    | "large"
+    | "showcase";
+
+  type Props = {
+    open: boolean;
+    onclose: () => void;
+    size?: DialogSize;
+    /** Accessible name. Omit when the content supplies `labelledBy`. */
+    ariaLabel?: string;
+    /** Id of a heading the content renders itself. */
+    labelledBy?: string;
+    /** Close button label, e.g. "Close settings". */
+    closeLabel?: string;
+    showClose?: boolean;
+    children: Snippet;
+  };
+
+  let {
+    open,
+    onclose,
+    size = "default",
+    ariaLabel,
+    labelledBy,
+    closeLabel = "Close dialog",
+    showClose = true,
+    children,
+  }: Props = $props();
+
+  const reducedMotion = new MediaQuery("(prefers-reduced-motion: reduce)");
+
+  let contentEl = $state<HTMLDivElement | null>(null);
+  let overlayCloseReady = $state(false);
+
+  // A click that opened the dialog must not also close it on the same
+  // gesture, so the overlay only arms after the first frame.
+  $effect(() => {
+    if (!open) {
+      overlayCloseReady = false;
+      return;
+    }
+    overlayCloseReady = false;
+    const frame = requestAnimationFrame(() => {
+      overlayCloseReady = true;
+    });
+    return () => cancelAnimationFrame(frame);
+  });
+
+  $effect(() => {
+    if (!open || !contentEl) return;
+    return trapFocus(contentEl, { onEscape: onclose });
+  });
+
+  function handleOverlayClick() {
+    if (!overlayCloseReady) return;
+    onclose();
+  }
+</script>
+
+{#if open}
+  <div class="modal-set">
+    <button
+      type="button"
+      class="overlay"
+      aria-label="Close dialog"
+      onclick={handleOverlayClick}
+      transition:fade={overlayFade(reducedMotion.current)}
+    ></button>
+    <div
+      bind:this={contentEl}
+      id="modal-content"
+      class="modal-content modal-content--{size}"
+      role="dialog"
+      aria-modal="true"
+      aria-label={ariaLabel}
+      aria-labelledby={labelledBy}
+      in:fly={modalContentReveal(reducedMotion.current)}
+      out:fly={modalContentDismiss(reducedMotion.current)}
+    >
+      {#if showClose}
+        <IconButton
+          class="modal-content__close-icon"
+          label={closeLabel}
+          onclick={onclose}
+        >
+          <X size={20} aria-hidden="true" />
+        </IconButton>
+      {/if}
+      {@render children()}
+    </div>
+  </div>
+{/if}
+
+<style>
+  .modal-set {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    translate: -50% -50%;
+    padding: 0.75rem;
+    width: 100%;
+    height: 100dvh;
+    z-index: var(--z-modal, 100);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    box-sizing: border-box;
+    pointer-events: auto;
+  }
+
+  .modal-content {
+    position: relative;
+    flex: 0 1 64rem;
+    max-height: 90dvh;
+    min-height: 0;
+    background-color: #fff;
+    z-index: inherit;
+    border-radius: 1rem;
+    padding: 0.5rem;
+    display: flex;
+    flex-flow: column nowrap;
+    overflow: hidden;
+
+    :global(.modal-content__close-icon) {
+      position: absolute;
+      right: 0.25rem;
+      top: 0.25rem;
+      z-index: 1;
+      background-color: #fff;
+    }
+  }
+
+  .modal-content--compact {
+    flex: 0 1 32rem;
+  }
+
+  /* Prose and forms cap at a readable measure so lines stay short. */
+  .modal-content--reading {
+    flex: 0 1 38rem;
+  }
+
+  /* Task surfaces take most of the screen. */
+  .modal-content--large {
+    flex: 0 1 72rem;
+    width: 100%;
+    height: min(90dvh, 56rem);
+  }
+
+  .modal-content--showcase {
+    flex: 0 1 48rem;
+    width: 100%;
+    max-height: min(92dvh, 52rem);
+    padding: 0;
+  }
+
+  @media only screen and (max-width: 31.25rem) {
+    .modal-content {
+      padding: 0.25rem;
+    }
+
+    .modal-content--showcase {
+      padding: 0;
+    }
+  }
+
+  .overlay {
+    all: unset;
+    width: 100%;
+    height: 100%;
+    inset: 0;
+    position: absolute;
+    /* No backdrop-filter: blurring the full-viewport WebGL map stalls the
+       compositor for seconds (30s+ seen in prod), so the dialog mounts,
+       blocks input, and never paints. Dim only. */
+    background-color: hsla(0, 0%, 8%, 0.48);
+    cursor: pointer;
+  }
+
+  .overlay:focus-visible {
+    outline: 2px solid #fff;
+    outline-offset: -4px;
+  }
+</style>

--- a/src/components/svelte/modal/Modal.svelte
+++ b/src/components/svelte/modal/Modal.svelte
@@ -1,348 +1,51 @@
 <script lang="ts">
   import { modalStore } from "@lib/store.svelte";
-  import { fade, fly } from "svelte/transition";
-  import {
-    modalContentDismiss,
-    modalContentReveal,
-    overlayFade,
-  } from "@lib/motion";
-  import { trapFocus } from "@lib/focus-trap";
-  import { MediaQuery } from "svelte/reactivity";
-  import LandingModal from "./LandingModal.svelte";
-  import ScheduleModal from "./ScheduleModal.svelte";
-  import LeaderboardModal from "./LeaderboardModal.svelte";
-  import CoverageModal from "./CoverageModal.svelte";
-  import ChangelogModal from "./ChangelogModal.svelte";
-  import AnnouncementsModal from "./AnnouncementsModal.svelte";
-  import ProposalReviewPanel from "../ProposalReviewPanel.svelte";
-  import StudentOrgsModal from "./StudentOrgsModal.svelte";
-  import SettingsModal from "./SettingsModal.svelte";
-  import JeepneyRouteModal from "./JeepneyRouteModal.svelte";
-  import EditorToolsModal from "./EditorToolsModal.svelte";
-  import PrivacyModal from "./PrivacyModal.svelte";
-  import OfflineMapsModal from "./OfflineMapsModal.svelte";
-  import HotlinesModal from "./HotlinesModal.svelte";
-  import IconButton from "@ui/IconButton.svelte";
-  import X from "@lucide/svelte/icons/x";
+  import { MODAL_REGISTRY } from "@constants/modal-registry";
+  import Dialog from "./Dialog.svelte";
 
-  const reducedMotion = new MediaQuery("(prefers-reduced-motion: reduce)");
-
-  let modalContentEl = $state<HTMLDivElement | null>(null);
-  let overlayCloseReady = $state(false);
-
-  $effect(() => {
-    if (!modalStore.open) {
-      overlayCloseReady = false;
-      return;
-    }
-    overlayCloseReady = false;
-    const frame = requestAnimationFrame(() => {
-      overlayCloseReady = true;
-    });
-    return () => cancelAnimationFrame(frame);
-  });
-
-  const modalAriaLabel = $derived.by(() => {
-    if (modalStore.type === "landing") return undefined;
-    if (modalStore.type === "schedule-expand") return "Room schedule";
-    if (modalStore.type === "leaderboard") return "Contributor leaderboard";
-    if (modalStore.type === "coverage") return "Campus data coverage";
-    if (modalStore.type === "changelog") return "What's new";
-    if (modalStore.type === "announcements") return "Announcements";
-    if (modalStore.type === "review") return "Review suggested edits";
-    if (modalStore.type === "student-orgs") return "Student organizations";
-    if (modalStore.type === "settings") return "Settings";
-    if (modalStore.type === "jeepney-route") return "Jeepney route";
-    if (modalStore.type === "editor-tools") return "Editor tools";
-    if (modalStore.type === "privacy") return "Privacy policy";
-    if (modalStore.type === "offline-maps") return "Offline maps";
-    if (modalStore.type === "hotlines") return "Emergency hotlines";
-    return "Dialog";
-  });
+  /**
+   * Modal host. This file used to carry fifteen near-identical branches,
+   * each with its own close button and a width picked by nested ternary.
+   * It is now a lookup: the registry says what to render and how, Dialog
+   * owns the shell. Adding a modal touches the registry only.
+   */
+  const entry = $derived(
+    modalStore.open && modalStore.type
+      ? MODAL_REGISTRY[modalStore.type]
+      : undefined,
+  );
 
   function closeDialog() {
     modalStore.closeModal();
   }
-
-  function handleOverlayClick() {
-    if (!overlayCloseReady) return;
-    closeDialog();
-  }
-
-  $effect(() => {
-    if (!modalStore.open || !modalContentEl) return;
-    return trapFocus(modalContentEl, {
-      onEscape: closeDialog,
-    });
-  });
 </script>
 
-{#if modalStore.open}
-  <div class="modal-set">
-    <button
-      type="button"
-      class="overlay"
-      aria-label="Close dialog"
-      onclick={handleOverlayClick}
-      transition:fade={overlayFade(reducedMotion.current)}
-    ></button>
-    <div
-      bind:this={modalContentEl}
-      class="modal-content {modalStore.type === 'landing'
-        ? 'landing-modal-container'
-        : modalStore.type === 'leaderboard' || modalStore.type === 'coverage'
-          ? 'leaderboard-modal-container'
-          : modalStore.type === 'changelog' ||
-              modalStore.type === 'announcements' ||
-              modalStore.type === 'review'
-            ? 'modal-content--large'
-            : modalStore.type === 'settings' ||
-                modalStore.type === 'jeepney-route' ||
-                modalStore.type === 'editor-tools' ||
-                modalStore.type === 'privacy' ||
-                modalStore.type === 'offline-maps' ||
-                modalStore.type === 'hotlines'
-              ? 'modal-content--reading'
-              : ''}"
-      id="modal-content"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby={modalStore.type === "landing"
-        ? "landing-modal-title"
-        : modalStore.type === "leaderboard"
-          ? "leaderboard-modal-title"
-          : modalStore.type === "coverage"
-            ? "coverage-modal-title"
-            : undefined}
-      aria-label={modalAriaLabel}
-      in:fly={modalContentReveal(reducedMotion.current)}
-      out:fly={modalContentDismiss(reducedMotion.current)}
-    >
-      {#if modalStore.type === "landing"}
-        <LandingModal />
-      {:else if modalStore.type === "schedule-expand"}
-        <IconButton
-          class="modal-content__close-icon"
-          label="Close schedule"
-          onclick={closeDialog}
-        >
-          <X size={20} aria-hidden="true" />
-        </IconButton>
-        <ScheduleModal />
-      {:else if modalStore.type === "leaderboard"}
-        <IconButton
-          class="modal-content__close-icon"
-          label="Close leaderboard"
-          onclick={closeDialog}
-        >
-          <X size={20} aria-hidden="true" />
-        </IconButton>
-        <LeaderboardModal />
-      {:else if modalStore.type === "coverage"}
-        <IconButton
-          class="modal-content__close-icon"
-          label="Close data coverage"
-          onclick={closeDialog}
-        >
-          <X size={20} aria-hidden="true" />
-        </IconButton>
-        <CoverageModal />
-      {:else if modalStore.type === "changelog"}
-        <IconButton
-          class="modal-content__close-icon"
-          label="Close changelog"
-          onclick={closeDialog}
-        >
-          <X size={20} aria-hidden="true" />
-        </IconButton>
-        <ChangelogModal />
-      {:else if modalStore.type === "announcements"}
-        <IconButton
-          class="modal-content__close-icon"
-          label="Close announcements"
-          onclick={closeDialog}
-        >
-          <X size={20} aria-hidden="true" />
-        </IconButton>
-        <AnnouncementsModal />
-      {:else if modalStore.type === "review"}
-        <IconButton
-          class="modal-content__close-icon"
-          label="Close review"
-          onclick={closeDialog}
-        >
-          <X size={20} aria-hidden="true" />
-        </IconButton>
-        <div class="review-modal-scroll">
-          <ProposalReviewPanel />
-        </div>
-      {:else if modalStore.type === "student-orgs"}
-        <IconButton
-          class="modal-content__close-icon"
-          label="Close student organizations"
-          onclick={closeDialog}
-        >
-          <X size={20} aria-hidden="true" />
-        </IconButton>
-        <StudentOrgsModal />
-      {:else if modalStore.type === "settings"}
-        <IconButton
-          class="modal-content__close-icon"
-          label="Close settings"
-          onclick={closeDialog}
-        >
-          <X size={20} aria-hidden="true" />
-        </IconButton>
-        <SettingsModal />
-      {:else if modalStore.type === "jeepney-route"}
-        <IconButton
-          class="modal-content__close-icon"
-          label="Close jeepney route"
-          onclick={closeDialog}
-        >
-          <X size={20} aria-hidden="true" />
-        </IconButton>
-        <JeepneyRouteModal />
-      {:else if modalStore.type === "editor-tools"}
-        <IconButton
-          class="modal-content__close-icon"
-          label="Close editor tools"
-          onclick={closeDialog}
-        >
-          <X size={20} aria-hidden="true" />
-        </IconButton>
-        <EditorToolsModal />
-      {:else if modalStore.type === "privacy"}
-        <IconButton
-          class="modal-content__close-icon"
-          label="Close privacy policy"
-          onclick={closeDialog}
-        >
-          <X size={20} aria-hidden="true" />
-        </IconButton>
-        <PrivacyModal />
-      {:else if modalStore.type === "offline-maps"}
-        <IconButton
-          class="modal-content__close-icon"
-          label="Close offline maps"
-          onclick={closeDialog}
-        >
-          <X size={20} aria-hidden="true" />
-        </IconButton>
-        <OfflineMapsModal />
-      {:else if modalStore.type === "hotlines"}
-        <IconButton
-          class="modal-content__close-icon"
-          label="Close emergency hotlines"
-          onclick={closeDialog}
-        >
-          <X size={20} aria-hidden="true" />
-        </IconButton>
-        <HotlinesModal />
-      {/if}
-    </div>
-  </div>
+{#if entry}
+  {@const Content = entry.component}
+  <Dialog
+    open={modalStore.open}
+    onclose={closeDialog}
+    size={entry.size}
+    ariaLabel={entry.labelledBy ? undefined : entry.label}
+    labelledBy={entry.labelledBy}
+    closeLabel={entry.closeLabel ?? "Close dialog"}
+    showClose={entry.showClose ?? true}
+  >
+    {#if entry.scroll}
+      <div class="modal-scroll">
+        <Content />
+      </div>
+    {:else}
+      <Content />
+    {/if}
+  </Dialog>
 {/if}
 
 <style>
-  :global(hr) {
-    margin: 1rem 0;
-    border-width: 2px;
-    border-color: hsl(0, 0%, 90%);
-    border-style: solid;
-  }
-  :global(mark) {
-    background-color: hsl(5, 53%, 90%);
-  }
-  .modal-set {
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    translate: -50% -50%;
-    padding: 0.75rem;
-    width: 100%;
-    height: 100dvh;
-    z-index: var(--z-modal, 100);
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    box-sizing: border-box;
-    pointer-events: auto;
-  }
-  .review-modal-scroll {
+  .modal-scroll {
     min-height: 0;
     flex: 1 1 auto;
     overflow-y: auto;
     padding: 0.5rem 0.75rem 0.25rem;
-  }
-
-  .modal-content {
-    position: relative;
-    flex: 0 1 64rem;
-    max-height: 90dvh;
-    min-height: 0;
-    background-color: white;
-    z-index: inherit;
-    border-radius: 1rem;
-    padding: 0.5rem;
-    display: flex;
-    flex-flow: column nowrap;
-    overflow: hidden;
-    :global(.modal-content__close-icon) {
-      position: absolute;
-      right: 0.25rem;
-      top: 0.25rem;
-      z-index: 1;
-      background-color: #fff;
-    }
-  }
-  /* Task-focused dialogs (review queue, changelog) take most of the screen. */
-  .modal-content--large {
-    flex: 0 1 72rem;
-    width: 100%;
-    height: min(90dvh, 56rem);
-  }
-  /* Settings/route dialogs cap at a readable measure so lines stay short. */
-  .modal-content--reading {
-    flex: 0 1 38rem;
-  }
-  .leaderboard-modal-container {
-    flex: 0 1 32rem;
-  }
-  .landing-modal-container {
-    flex: 0 1 48rem;
-    width: 100%;
-    max-height: min(92dvh, 52rem);
-    padding: 0;
-    overflow: hidden;
-    min-height: 0;
-    display: flex;
-    flex-direction: column;
-  }
-  @media only screen and (max-width: 31.25rem) {
-    .modal-content {
-      padding: 0.25rem;
-    }
-    .landing-modal-container {
-      padding: 0;
-    }
-  }
-  .overlay {
-    all: unset;
-    width: 100%;
-    height: 100%;
-    inset: 0;
-    position: absolute;
-    /* No backdrop-filter here: blurring the full-viewport WebGL map stalls
-       the compositor for seconds (30s+ seen in prod) — the dialog mounts,
-       blocks all input, and never paints. Verified: with blur the Settings
-       modal takes 5-8s to appear locally, without it ~1 frame. Dim only. */
-    background-color: hsla(0, 0%, 8%, 0.48);
-    cursor: pointer;
-  }
-
-  .overlay:focus-visible {
-    outline: 2px solid white;
-    outline-offset: -4px;
   }
 </style>

--- a/src/constants/modal-registry.ts
+++ b/src/constants/modal-registry.ts
@@ -1,0 +1,129 @@
+import type { Component } from "svelte";
+import type { DialogSize } from "@ui/modal/Dialog.svelte";
+import AnnouncementsModal from "@ui/modal/AnnouncementsModal.svelte";
+import ChangelogModal from "@ui/modal/ChangelogModal.svelte";
+import CoverageModal from "@ui/modal/CoverageModal.svelte";
+import EditorToolsModal from "@ui/modal/EditorToolsModal.svelte";
+import HotlinesModal from "@ui/modal/HotlinesModal.svelte";
+import JeepneyRouteModal from "@ui/modal/JeepneyRouteModal.svelte";
+import LandingModal from "@ui/modal/LandingModal.svelte";
+import LeaderboardModal from "@ui/modal/LeaderboardModal.svelte";
+import OfflineMapsModal from "@ui/modal/OfflineMapsModal.svelte";
+import PrivacyModal from "@ui/modal/PrivacyModal.svelte";
+import ProposalReviewPanel from "@ui/ProposalReviewPanel.svelte";
+import ScheduleModal from "@ui/modal/ScheduleModal.svelte";
+import SettingsModal from "@ui/modal/SettingsModal.svelte";
+import StudentOrgsModal from "@ui/modal/StudentOrgsModal.svelte";
+import type { modalOptions } from "@constants/modal-states";
+
+export type ModalType = (typeof modalOptions)[number];
+
+export type ModalEntry = {
+  component: Component<Record<string, never>>;
+  size: DialogSize;
+  /** Accessible name. Omit only when `labelledBy` is set. */
+  label?: string;
+  /** Id of a heading the modal content renders itself. */
+  labelledBy?: string;
+  /** Close button label. Defaults to "Close dialog". */
+  closeLabel?: string;
+  /** Content that paints its own chrome supplies its own dismiss. */
+  showClose?: boolean;
+  /** Wrap children in a scroll region (long task surfaces). */
+  scroll?: boolean;
+};
+
+/**
+ * Every modal the app can open, declared once. Adding a modal means adding
+ * a row here, not another branch in a ternary. Labels are load-bearing:
+ * they are the accessible names the e2e suite and screen readers use.
+ */
+export const MODAL_REGISTRY: Record<ModalType, ModalEntry> = {
+  landing: {
+    component: LandingModal,
+    size: "showcase",
+    labelledBy: "landing-modal-title",
+    showClose: false,
+  },
+  "schedule-expand": {
+    component: ScheduleModal,
+    size: "default",
+    label: "Room schedule",
+    closeLabel: "Close schedule",
+  },
+  leaderboard: {
+    component: LeaderboardModal,
+    size: "compact",
+    label: "Contributor leaderboard",
+    labelledBy: "leaderboard-modal-title",
+    closeLabel: "Close leaderboard",
+  },
+  coverage: {
+    component: CoverageModal,
+    size: "compact",
+    label: "Campus data coverage",
+    labelledBy: "coverage-modal-title",
+    closeLabel: "Close data coverage",
+  },
+  changelog: {
+    component: ChangelogModal,
+    size: "large",
+    label: "What's new",
+    closeLabel: "Close changelog",
+  },
+  announcements: {
+    component: AnnouncementsModal,
+    size: "large",
+    label: "Announcements",
+    closeLabel: "Close announcements",
+  },
+  review: {
+    component: ProposalReviewPanel,
+    size: "large",
+    label: "Review suggested edits",
+    closeLabel: "Close review",
+    scroll: true,
+  },
+  "student-orgs": {
+    component: StudentOrgsModal,
+    size: "default",
+    label: "Student organizations",
+    closeLabel: "Close student organizations",
+  },
+  settings: {
+    component: SettingsModal,
+    size: "reading",
+    label: "Settings",
+    closeLabel: "Close settings",
+  },
+  "jeepney-route": {
+    component: JeepneyRouteModal,
+    size: "reading",
+    label: "Jeepney route",
+    closeLabel: "Close jeepney route",
+  },
+  "editor-tools": {
+    component: EditorToolsModal,
+    size: "reading",
+    label: "Editor tools",
+    closeLabel: "Close editor tools",
+  },
+  privacy: {
+    component: PrivacyModal,
+    size: "reading",
+    label: "Privacy policy",
+    closeLabel: "Close privacy policy",
+  },
+  "offline-maps": {
+    component: OfflineMapsModal,
+    size: "reading",
+    label: "Offline maps",
+    closeLabel: "Close offline maps",
+  },
+  hotlines: {
+    component: HotlinesModal,
+    size: "reading",
+    label: "Emergency hotlines",
+    closeLabel: "Close emergency hotlines",
+  },
+};

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,1 +1,14 @@
 @import "tailwindcss";
+
+/* Moved out of Modal.svelte when the dialog shell was extracted (these are
+   global element styles, they were never modal-specific). */
+hr {
+  margin: 1rem 0;
+  border-width: 2px;
+  border-color: hsl(0, 0%, 90%);
+  border-style: solid;
+}
+
+mark {
+  background-color: hsl(5, 53%, 90%);
+}


### PR DESCRIPTION
Closes the "design one modal that is the parent of all modals" ask, and fixes Map tools being too small to use.

## Before

`Modal.svelte` was ~350 lines of fifteen near-identical branches. Each branch hand-rolled its own close `IconButton`, and the dialog width and `aria-label` came out of nested ternaries over the modal type. Nothing stopped two modals from drifting apart, and several had.

Map tools was not a modal at all. It rendered as a popover anchored under its trigger, with a `$effect` measuring the viewport to pick a max-height. On anything but a tall screen it was a cramped column.

## After

**`modal/Dialog.svelte`** is the only dialog shell in the app. Overlay, focus trap, escape handling, enter/exit motion, sizing, and the single close button live there and nowhere else.

Sizes are intents rather than pixel values, so a new modal picks a role instead of guessing a width:

| size | for |
| --- | --- |
| `compact` | a short list or summary |
| `reading` | prose and forms, capped at a readable measure |
| `default` | general content |
| `large` | task surfaces (review queue, changelog) |
| `showcase` | content that paints its own chrome to the edges (landing) |

**`constants/modal-registry.ts`** declares every modal once: component, size, accessible name, close-button label, whether it scrolls. Adding a modal is a row in a table now, not another branch. The labels are load-bearing, they are the accessible names both the e2e suite and screen readers go through, so they live next to the component they name.

**`Modal.svelte`** drops to a lookup, about 50 lines.

**Map tools** opens as `Dialog size="large"` and lays its tools out in two columns above 48rem. The viewport-measuring effect, `panelEl`, `shellEl`, and the panel shell import are all deleted, since a dialog just scrolls its own body. `mapToolsStore` keeps its exact API, so its unit tests and `openSection` in `map-chrome.ts` are untouched.

Global `hr` and `mark` rules moved to `global.css`, where they always belonged.

## Preserved on purpose

- `.modal-set`, `.modal-content`, `.overlay`, and the overlay's `aria-label="Close dialog"`, because the e2e suite selects on them.
- No `backdrop-filter` on the overlay. Blurring the full-viewport WebGL map stalls the compositor for 30s+ in production, so the dialog mounts, blocks input, and never paints. The comment explaining that moved into `Dialog.svelte` so the next person does not "improve" it back.
- The overlay only arms its close handler after one frame, so the click that opened a dialog cannot also close it.

## Verification

- `bun run build` exits 0
- `bun run test`: 886 pass, 0 fail
- Playwright desktop-chrome, 20/20 on `app-menu.spec.ts today-route.spec.ts campus-browse-chips.spec.ts academic-calendar-route.spec.ts`, including `getByRole("dialog", { name: "Map tools" })` and "Map tools routes today's classes from the map"

https://claude.ai/code/session_01JFbuFTv5rhkvSyZs7DT8ce