### PR TITLE
fix(pwa): stop content pages from precaching the whole app

### DIFF
--- a/e2e/smoke/content-page-no-service-worker.spec.ts
+++ b/e2e/smoke/content-page-no-service-worker.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Registering the service worker precaches the whole app (~10 MB across 87
+ * files at the time of writing). That is right for the map and wrong for a
+ * wiki article someone reached from a search result, so src/pwa.ts registers
+ * only where <html data-app-page="true"> says the app actually mounts.
+ *
+ * The attribute is the contract between the layout and that module. Assert it
+ * rather than the worker itself: whether a worker registers at all depends on
+ * how the preview build was produced, but this flag is what decides it.
+ */
+test.describe("service worker scope", () => {
+  test("content pages do not opt into the service worker", async ({ page }) => {
+    for (const path of ["/wiki", "/faq", "/privacy", "/changelog"]) {
+      await page.goto(path);
+      await expect(
+        page.locator("html"),
+        `${path} should not be marked as an app page`,
+      ).not.toHaveAttribute("data-app-page", "true");
+    }
+  });
+
+  test("the map app still opts in", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator("html")).toHaveAttribute("data-app-page", "true");
+  });
+});

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -33,6 +33,16 @@ type Props = {
   structuredData?: StructuredData[];
   /** Map app shell only: static pages (changelog, legal) should disable this. */
   showAppLoadingShell?: boolean;
+  /**
+   * Whether this page mounts the map app. Content pages (wiki, legal, FAQ)
+   * leave it off, which keeps the service worker from registering there:
+   * registering precaches the whole app, so a reader who arrived at one wiki
+   * article from search was pulling 10 MB across 87 files in the background
+   * for a 15 KB page. Defaults to whatever the loading shell does, since the
+   * two have always meant the same thing, but stays separate so an app page
+   * can hide the shell without also losing offline support.
+   */
+  isAppPage?: boolean;
   /** Load the AdSense script. Wiki pages only — never the map (docs/ad-policy.md). */
   enableAds?: boolean;
 };
@@ -46,16 +56,21 @@ const {
   robots = "index,follow",
   structuredData = [],
   showAppLoadingShell = true,
+  isAppPage = showAppLoadingShell,
   enableAds = false,
 }: Props = Astro.props;
 
+// isAppPage rides on the document as data-app-page rather than reaching
+// src/pwa.ts as a prop, because Astro hoists <script> tags regardless of any
+// condition wrapped around them. The registration module loads on every page
+// either way, so it has to read the flag and decide for itself.
 const canonicalUrl = absoluteUrl(canonicalPath);
 const imageUrl = absoluteUrl(imagePath);
 const shareTitle = ogTitle ?? title;
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang="en" data-app-page={isAppPage ? "true" : undefined}>
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/src/pwa.ts
+++ b/src/pwa.ts
@@ -12,19 +12,28 @@ import { registerSW } from "virtual:pwa-register";
 const NEED_REFRESH_EVENT = "pwa:need-refresh";
 const APPLY_UPDATE_EVENT = "pwa:apply-update";
 
-const updateSW = registerSW({
-  immediate: true,
-  onNeedRefresh() {
-    // The island usually mounts after this fires, so latch it on the document
-    // as well: StatusBar reads the flag on mount and would otherwise miss the
-    // event entirely.
-    document.documentElement.dataset.pwaNeedRefresh = "true";
-    window.dispatchEvent(new Event(NEED_REFRESH_EVENT));
-  },
-});
+// Only the map app gets a service worker. Registering one precaches the whole
+// app, so a reader who landed on a single wiki article from search used to
+// pull ~10 MB across 87 files in the background to read a 15 KB page. Layout
+// sets data-app-page on <html>; content pages leave it off. An already
+// registered worker is left alone, since those visitors have used the app.
+const isAppPage = document.documentElement.dataset.appPage === "true";
+
+const updateSW = isAppPage
+  ? registerSW({
+      immediate: true,
+      onNeedRefresh() {
+        // The island usually mounts after this fires, so latch it on the
+        // document as well: StatusBar reads the flag on mount and would
+        // otherwise miss the event entirely.
+        document.documentElement.dataset.pwaNeedRefresh = "true";
+        window.dispatchEvent(new Event(NEED_REFRESH_EVENT));
+      },
+    })
+  : null;
 
 // The refresh button lives in the app UI, which cannot reach this module
 // directly.
 window.addEventListener(APPLY_UPDATE_EVENT, () => {
-  void updateSW(true);
+  void updateSW?.(true);
 });


### PR DESCRIPTION
Reported as "if I go to room-tba.uplb.tools/wiki it goes through the entire Room TBA loading process."

## What is actually happening

The page itself is fine. `/wiki` renders server side in 331 ms over 15 KB with no `AppRoot` island and no loading shell. What is not fine is what happens after it paints.

Every page runs `import "../pwa"` from `Layout.astro`, so every page registers the service worker, and registering it precaches the app. Measured on production from a clean profile, right after loading one wiki article:

```
workbox-precache-v2-https://room-tba.uplb.tools/   87 entries   10.75 MB
```

Someone who arrived from a search result to read about campus curfew downloads the whole map app in the background, on mobile data, to read 15 KB of text.

## The change

`Layout.astro` marks the map app with `data-app-page` on `<html>`. `src/pwa.ts` registers only when that flag is set.

The flag defaults to `showAppLoadingShell`, so the eleven pages that already opt out of the loading shell (wiki, FAQ, terms, privacy, changelog, sponsors, donate, route pages, reset-password, pubmat, fork) need no edit. It is still a separate prop, because the two are not the same statement: an app page might want to hide the shell for a design reason, and it should not silently lose offline support when it does.

It rides on the document instead of reaching `pwa.ts` as a prop because Astro hoists `<script>` tags regardless of any condition wrapped around them. The module loads on every page either way, so it has to read the flag and decide for itself.

## What nobody loses

- The wiki pages are still in the precache manifest, so anyone who opens the map keeps them available offline. Only visitors who never touch the app skip the download, which is the point.
- An already registered worker is untouched. Those visitors have used the app.
- Registration stays outside the `AppRoot` island, which is what lets a stale worker get replaced when the app bundle itself is broken (see the comment at the top of `src/pwa.ts`).

## Verification

- `bun run build`: `/` emits `data-app-page="true"`, `/wiki` and `/faq` emit no such attribute
- `bun run test`: 886 pass, 0 fail
- `bun run lint`: clean
- Playwright desktop-chrome: `boot.spec.ts` and `redirects.spec.ts` pass, plus a new `content-page-no-service-worker.spec.ts` asserting the contract in both directions

`entity-pages.spec.ts` fails locally with a 500 because `E2E_DATABASE_URL` is not set in this environment. Unrelated to this change, and CI has the secret.

## Related

The same class of bug, a service worker outliving the site it was installed for, is why www.uplb.tools currently shows Room TBA's failure card: uplbtools/website#24.

https://claude.ai/code/session_01JFbuFTv5rhkvSyZs7DT8ce