### PR TITLE
fix(proposals): refresh the open room panel after an approve

### DIFF
--- a/src/lib/proposals/sync-open-entity-query.store.test.ts
+++ b/src/lib/proposals/sync-open-entity-query.store.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { AppContextData } from "@lib/context";
+import type { RoomData } from "@lib/types";
+
+const { getJSONFetch, getLocalRoomByCode } = vi.hoisted(() => ({
+  getJSONFetch: vi.fn(),
+  getLocalRoomByCode: vi.fn(),
+}));
+
+vi.mock("../local/data/utils.js", () => ({
+  getJSONFetch,
+  getLocalRoomByCode,
+  getBuildingIdsWithClasses: vi.fn(),
+  getLocalClassesForRoom: vi.fn(),
+  getLocalBuildingRooms: vi.fn(),
+}));
+
+import { currentRoom, queryStore } from "@lib/store.svelte";
+import { syncOpenEntityQueryAfterPublish } from "./sync-open-entity-query";
+
+const room = (id: number, code: string, directions: string | null): RoomData =>
+  ({ id, code, directions, version: 2 }) as unknown as RoomData;
+
+const noAppData = () => ({ loaded: false }) as AppContextData;
+
+function openRoomQuery(code: string) {
+  queryStore.updateQuery({ type: "result", category: "room", value: code });
+}
+
+describe("syncOpenEntityQueryAfterPublish room", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    openRoomQuery("E2E-101");
+  });
+
+  test("replaces the room on screen with the published row", () => {
+    currentRoom.setRoom(room(1, "E2E-101", "Old directions"));
+
+    syncOpenEntityQueryAfterPublish(
+      noAppData,
+      "room",
+      room(1, "E2E-101", "New directions"),
+    );
+
+    expect(currentRoom.value?.directions).toBe("New directions");
+  });
+
+  test("still lands when the room lookup has not resolved yet", async () => {
+    let resolveLookup!: (value: RoomData | null) => void;
+    getLocalRoomByCode.mockReturnValue(
+      new Promise<RoomData | null>((resolve) => {
+        resolveLookup = resolve;
+      }),
+    );
+    const lookup = currentRoom.getRoomByCode("E2E-101");
+    expect(currentRoom.value).toBeNull();
+
+    syncOpenEntityQueryAfterPublish(
+      noAppData,
+      "room",
+      room(1, "E2E-101", "New directions"),
+    );
+
+    // The in-flight lookup answers with the pre-approval row; it must lose.
+    resolveLookup(room(1, "E2E-101", "Old directions"));
+    await lookup;
+    expect(currentRoom.value?.directions).toBe("New directions");
+  });
+
+  test("leaves another room alone", () => {
+    currentRoom.setRoom(room(1, "E2E-101", "Old directions"));
+
+    syncOpenEntityQueryAfterPublish(
+      noAppData,
+      "room",
+      room(2, "E2E-202", "New directions"),
+    );
+
+    expect(currentRoom.value?.directions).toBe("Old directions");
+  });
+
+  test("renames the open query so the URL follows a published room code", () => {
+    currentRoom.setRoom(room(1, "E2E-101", null));
+
+    syncOpenEntityQueryAfterPublish(
+      noAppData,
+      "room",
+      room(1, "E2E-999", null),
+    );
+
+    expect(queryStore.queryValue).toBe("E2E-999");
+  });
+});

--- a/src/lib/proposals/sync-open-entity-query.ts
+++ b/src/lib/proposals/sync-open-entity-query.ts
@@ -1,4 +1,4 @@
-import { queryStore } from "@lib/store.svelte";
+import { currentRoom, queryStore } from "@lib/store.svelte";
 import type { AppContextData } from "@lib/context";
 import type { ProposalEntityType } from "@lib/services/proposal-service";
 import type {
@@ -7,9 +7,36 @@ import type {
   DivisionData,
   DormData,
   EventData,
+  RoomData,
 } from "@lib/types";
 
 type PublishedRow = { id: number };
+
+/**
+ * Campus app data does not carry rooms (they load per building), so
+ * `applyPublishedEntity` has no room case and the campus refresh it falls back
+ * to never touches the rooms table. Without this the open room panel keeps the
+ * pre-approval value until the browser reloads.
+ */
+function syncOpenRoom(published: RoomData): void {
+  if (queryStore.category !== "room") return;
+  const open = currentRoom.value;
+  // The lookup started by opening the room can still be in flight when an
+  // approve lands, so fall back to the code the query was opened with.
+  // `setRoom` bumps the room load generation, which makes that lookup drop its
+  // result instead of writing the pre-approval row over this one.
+  const isOpen = open
+    ? open.id === published.id
+    : queryStore.queryValue.toUpperCase() === published.code.toUpperCase();
+  if (!isOpen) return;
+
+  currentRoom.setRoom(published);
+  queryStore.hydrateQuery({
+    type: "result",
+    category: "room",
+    value: published.code,
+  });
+}
 
 function openEntityId(
   data: AppContextData,
@@ -47,7 +74,7 @@ function openEntityId(
   }
 }
 
-/** Keep the open side panel pointed at the entity after approve renames it. */
+/** Keep the open side panel pointed at the entity a publish just changed. */
 export function syncOpenEntityQueryAfterPublish(
   getData: () => AppContextData,
   entityType: ProposalEntityType,
@@ -58,6 +85,11 @@ export function syncOpenEntityQueryAfterPublish(
   }
   const publishedId = Number((published as PublishedRow).id);
   if (!Number.isInteger(publishedId)) return;
+
+  if (entityType === "room") {
+    syncOpenRoom(published as RoomData);
+    return;
+  }
 
   const data = getData();
   const openId = openEntityId(data, queryStore.category, queryStore.queryValue);


### PR DESCRIPTION
## Root cause

`e2e/admin/proposals.spec.ts:64` is red on main and blocks #1146, #1149 and #1150. It is a product bug, not test rot.

`applyPublishedEntity` returns `false` for `room` and `create_room` (`src/lib/proposals/apply-published-entity.ts:132-135`), so `afterProposalPublished` falls through to `invalidateLocalSyncKeys(["rooms"])` plus `requestCampusDataRefresh()`. That refresh runs `refreshFromNetwork` in `src/components/svelte/AppRoot.svelte:191-209`, which syncs buildings, colleges, divisions, dorms, events, classes, organizations and places. Rooms are not in the list: they load per building behind the `rooms_fetched` flag. So approving a room suggestion published the row server side and nothing on the client ever re-read it. An editor approved an edit and the map kept showing the old directions until a reload.

The undo hold added in #895 makes the e2e hit this every run. Approve puts the proposal in a 7s local hold and the row leaves the queue immediately, so `openRoom()` fires the room lookup in the same tick that the panel unmount flushes the approve POST. The lookup wins, the panel renders the pre-approval value, and nothing updates it when the write lands.

## Fix

`syncOpenEntityQueryAfterPublish` already exists to keep the open side panel pointed at whatever a publish changed, so the room case goes there: write the published row into `currentRoom` and re-point the query. That is the same pair `RoomResult.syncRoomFromServer` (`src/components/svelte/room/RoomResult.svelte:215-222`) already runs when an editor publishes the field directly, and the payload is identical (both come from `updateRoom`).

The room can still be loading when the approve lands, so when `currentRoom` is null the open room is identified by the code the query carries. `currentRoom.setRoom` bumps the room load generation, so the in-flight lookup drops its pre-approval result instead of overwriting the published one.

`EntityHistoryPanel` calls the same function, so a room revert now refreshes the open panel too.

## Verified

- `bun run build` (with `DATABASE_URL`) passes.
- `bun run test`: 886 pass, 0 fail.
- `bunx vitest run`: 72 files, 327 tests pass, including the new `src/lib/proposals/sync-open-entity-query.store.test.ts`. Stubbing out the new branch turns 3 of its 4 tests red, so the check bites.
- `bunx --bun biome check` clean on both touched files.
- Not verified: the Playwright spec itself. It needs a seeded Postgres and `E2E_DATABASE_URL`, which this machine does not have, so admin and entity specs 500 locally. The e2e conclusion comes from reading the approve path end to end, not from a local run.

https://claude.ai/code/session_01JFbuFTv5rhkvSyZs7DT8ce
