### PR TITLE
fix(proposals): write an approved room to the local cache

### DIFF
--- a/src/components/svelte/ProposalReviewPanel.svelte
+++ b/src/components/svelte/ProposalReviewPanel.svelte
@@ -157,7 +157,7 @@
     const entityType = (data as { proposal?: { entityType?: string } }).proposal
       ?.entityType;
     if (entityType) {
-      afterProposalPublished(
+      await afterProposalPublished(
         appActions,
         appData,
         entityType as ProposalEntityType,

--- a/src/components/svelte/editor/EntityHistoryPanel.svelte
+++ b/src/components/svelte/editor/EntityHistoryPanel.svelte
@@ -97,7 +97,7 @@
         );
         return;
       }
-      afterProposalPublished(
+      await afterProposalPublished(
         appActions,
         appData,
         entityType as ProposalEntityType,

--- a/src/lib/local/data/sync.ts
+++ b/src/lib/local/data/sync.ts
@@ -785,6 +785,57 @@ export async function checkLocalBuildingRoom(id: number) {
   }
 }
 
+/**
+ * Write one room into the local cache.
+ *
+ * Rooms are the only entity that loads lazily, per building, behind
+ * `buildings.rooms_fetched`. Nothing in the campus refresh touches the rooms
+ * table, so a room the server just changed stays stale locally until someone
+ * reopens its building. Publishing an edit has to write the row itself.
+ *
+ * Deliberately not `syncBuildingRooms` with a one-room array: that marks the
+ * whole building as fetched, which would be a lie about the other rooms.
+ */
+export async function upsertLocalRoom(room: RoomData): Promise<void> {
+  try {
+    const localDB = await getDB();
+    await localDB.waitReady;
+    await localDB.query(
+      `
+            INSERT INTO rooms (id, room_code, directions, building_id, college_id, division_id, image_url, version, updated_at, category, full_name)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+            ON CONFLICT (id) DO UPDATE SET
+            room_code = EXCLUDED.room_code,
+            directions = EXCLUDED.directions,
+            building_id = EXCLUDED.building_id,
+            college_id = EXCLUDED.college_id,
+            division_id = EXCLUDED.division_id,
+            image_url = EXCLUDED.image_url,
+            version = EXCLUDED.version,
+            updated_at = EXCLUDED.updated_at,
+            category = EXCLUDED.category,
+            full_name = EXCLUDED.full_name;
+            `,
+      [
+        room.id,
+        room.code,
+        room.directions,
+        room.buildingId,
+        room.collegeId,
+        room.divisionId,
+        room.imageUrl ?? null,
+        room.version,
+        room.updatedAt,
+        room.category ?? null,
+        room.fullName ?? null,
+      ],
+    );
+  } catch (e) {
+    // A publish must not fail because the local cache did.
+    console.error("upsertLocalRoom failed", e);
+  }
+}
+
 export async function syncBuildingRooms(
   validSync: boolean,
   id: number,

--- a/src/lib/proposals/apply-published-entity.store.test.ts
+++ b/src/lib/proposals/apply-published-entity.store.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { AppActions, AppContextData } from "@lib/context";
+import type { RoomData } from "@lib/types";
+
+const { upsertLocalRoom } = vi.hoisted(() => ({
+  upsertLocalRoom: vi.fn(async () => {}),
+}));
+vi.mock("@lib/local/data/sync", () => ({ upsertLocalRoom }));
+
+import { afterProposalPublished } from "./apply-published-entity";
+
+const actions = {
+  upsertBuilding: vi.fn(),
+  upsertDorm: vi.fn(),
+  upsertCollege: vi.fn(),
+  upsertDivision: vi.fn(),
+  upsertPlace: vi.fn(),
+  upsertOrganization: vi.fn(),
+  replaceEvent: vi.fn(),
+} as unknown as AppActions;
+
+const noData = () => ({ loaded: false }) as AppContextData;
+
+const room = (directions: string): RoomData =>
+  ({
+    id: 42,
+    code: "E2E-101",
+    directions,
+    buildingId: 1,
+    collegeId: null,
+    divisionId: null,
+    version: 3,
+    updatedAt: "2026-09-09T00:00:00.000Z",
+  }) as unknown as RoomData;
+
+/**
+ * Rooms load lazily per building and the campus refresh never syncs them, so
+ * an approved room edit only reaches the client if the publish writes the row
+ * to PGlite itself. Reopening the room reads that table straight back, which
+ * is why the write is awaited rather than fired off.
+ */
+describe("afterProposalPublished rooms", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("writes the published room to the local cache", async () => {
+    await afterProposalPublished(
+      actions,
+      noData,
+      "room",
+      room("New directions"),
+    );
+
+    expect(upsertLocalRoom).toHaveBeenCalledTimes(1);
+    expect(upsertLocalRoom.mock.calls[0]?.[0]).toMatchObject({
+      id: 42,
+      code: "E2E-101",
+      directions: "New directions",
+    });
+  });
+
+  test("a newly created room lands too", async () => {
+    await afterProposalPublished(actions, noData, "create_room", room("Fresh"));
+    expect(upsertLocalRoom).toHaveBeenCalledTimes(1);
+  });
+
+  test("the write finishes before the call resolves", async () => {
+    let settled = false;
+    upsertLocalRoom.mockImplementationOnce(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      settled = true;
+    });
+
+    await afterProposalPublished(actions, noData, "room", room("Slow write"));
+
+    expect(settled).toBe(true);
+  });
+
+  test("leaves other entity types alone", async () => {
+    await afterProposalPublished(actions, noData, "building", {
+      id: 1,
+      buildingName: "Humanities",
+    });
+    expect(upsertLocalRoom).not.toHaveBeenCalled();
+  });
+
+  test("ignores a payload that is not a room row", async () => {
+    await afterProposalPublished(actions, noData, "room", { nope: true });
+    expect(upsertLocalRoom).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/proposals/apply-published-entity.ts
+++ b/src/lib/proposals/apply-published-entity.ts
@@ -7,6 +7,7 @@ import type {
   EventData,
   OrgData,
   PlaceData,
+  RoomData,
 } from "@lib/types";
 import type { ProposalEntityType } from "@lib/services/proposal-service";
 import {
@@ -141,16 +142,34 @@ export function applyPublishedEntity(
   }
 }
 
-export function afterProposalPublished(
+function isRoomRow(value: unknown): value is RoomData {
+  if (!value || typeof value !== "object") return false;
+  const row = value as Partial<RoomData>;
+  return typeof row.id === "number" && typeof row.code === "string";
+}
+
+export async function afterProposalPublished(
   actions: AppActions,
   getData: () => AppContextData,
   entityType: ProposalEntityType,
   published: unknown,
-): void {
+): Promise<void> {
   const applied = applyPublishedEntity(actions, entityType, published, getData);
   const tables = syncTablesForEntityType(entityType);
   if (tables.length > 0) {
     invalidateLocalSyncKeys(tables);
+  }
+
+  // Rooms have no in-memory list to upsert into and the campus refresh never
+  // syncs them, so the published row has to reach PGlite directly. Awaited,
+  // because reopening the room reads that table straight back and would
+  // otherwise race the write and show the pre-approval value.
+  if (
+    (entityType === "room" || entityType === "create_room") &&
+    isRoomRow(published)
+  ) {
+    const { upsertLocalRoom } = await import("@lib/local/data/sync");
+    await upsertLocalRoom(published);
   }
   if (applied) {
     // In-memory upsert is authoritative for the open panel. A full campus


### PR DESCRIPTION
Follow-up to #1154, which fixed half of this. The e2e still failed after it merged, so here is the other half.

## What #1154 missed

It corrected the in-memory `currentRoom` at publish time. But the failing test reopens the room right after:

```js
await proposal.getByRole("button", { name: "Approve" }).click();
await expect(proposal).toBeHidden({ timeout: 15_000 });
await openRoom(page);
await expect(page.getByText(marker)).toBeVisible({ timeout: 15_000 });  // still failed
```

`openRoom()` is a fresh search-and-select, so it runs `getLocalRoomByCode`, which reads the PGlite `rooms` table and overwrites the in-memory row #1154 had just corrected. Approve an edit, reopen the room, see the old value.

## Why the row was stale

Rooms are the only entity that loads lazily, per building, behind `buildings.rooms_fetched`:

- `applyPublishedEntity` has no `room` case, it returns `false`.
- The campus refresh it falls back to syncs eight tables, and `rooms` is not one of them.
- `invalidateLocalSyncKeys(["rooms"])` only deletes a localStorage key. That changes nothing until someone reopens the building, which is exactly what the test does not do.

So nothing rewrote that row, ever.

## The change

`upsertLocalRoom(room)` in the local data layer writes one row, and `afterProposalPublished` awaits it for `room` and `create_room`.

Awaited, not fired off: the reopen reads that table straight back, so a floating promise would race the read and the test would pass or fail on timing. Both call sites (`ProposalReviewPanel`, `EntityHistoryPanel`) were already in `async` functions, so awaiting cost nothing.

Deliberately **not** `syncBuildingRooms` with a one-room array. That function ends with `UPDATE buildings SET rooms_fetched = true`, which would claim every other room in the building had been fetched.

Everything else is unchanged: rooms still return `false` from `applyPublishedEntity`, so the existing campus refresh still fires exactly as before. This only adds the write that was missing.

## Verification

- `bun run build` exits 0
- `bun run test`: 886 pass
- `bunx vitest run`: 332 pass across 73 files, up from 327
- `bunx --bun biome check`: clean on all five files touched
- The new test bites: commenting out the upsert call turns 3 of its 5 cases red, then green again on restore

I could not run the Playwright spec locally, `E2E_DATABASE_URL` is not set here so the admin specs 500. CI on this PR is the real check.

https://claude.ai/code/session_01JFbuFTv5rhkvSyZs7DT8ce