### PR TITLE
docs(credits): align README and in-app credits with the team roster

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,46 +43,46 @@ Under the hood it is a campus platform, not a UPLB-only app: the engine (map UI,
 
 ## What you can do
 
-| Goal | How |
-| ----------------------------- | ---------------------------------------------------------------- |
-| Find **PSLH 1** or **PhySci** | Search + aliases (`PhySci`, `HUM`, …) |
-| Room schedule this sem | Term filter + timetable |
-| Personal schedule route | Build a plan in Planner → Map tools → Schedule → pick a day, route stops |
-| Browse all classes | Status bar → Browse classes; search by course code |
-| Section with no room yet | "No assigned room" rows hint the offering department and where the course usually meets (#846) |
-| Plan your classes | Planner view to build a draft schedule |
-| What do I have today | Today view (`/today`): your plan's classes for today, tomorrow, and the rest of the week; one tap routes the day on the map with total walking time and distance (`/today?route=1`) |
-| Course Planner explainer | [Four-panel, screenshot-ready guide](https://room-tba.uplb.tools/pubmat/course-planner/) |
-| Final exam time & room | Search course code → finals panel; room panel during finals week |
-| Academic calendar | [/calendar](https://room-tba.uplb.tools/calendar) — term windows on a year timeline; also via the term picker |
-| Building location | Map, pins, directions, Google Maps |
-| Compare dorm listings | Verified dorms link to their Kubo listing when available |
-| Landmarks, services, orgs & offices | Map filters and the App menu, distinct map pins, and shareable detail links |
-| Offline / bad signal | PWA + local cache; tiles if already loaded |
-| Campus events | Events on map with routes |
-| Jeepney routes | Route overlays |
-| Walking time from a point | Map tools → Travel time; tap the map, paths color by minutes |
-| Measure a route | Map tools → Measure route; drop waypoints, get walk / cycle / car times |
-| 3D view | Buildings + Makiling terrain (online) |
-| Satellite imagery | Map tools → View → Satellite; choose locally changed historical imagery back to 2015 when online |
-| Common questions | [Student FAQ](https://room-tba.uplb.tools/faq) (3D models, data sources, offline) |
-| Tell us something is wrong | Settings → Feedback; free text, optional contact, or reach the team on Messenger / Discord |
-| Understand section names | Wiki guide to the A–H / S–Z class time blocks |
-| Find emergency contacts | Menu → Emergency hotlines; bundled for offline use |
-| Check dorm curfew rules | UP-managed dorm details → Curfew & permits |
+| Goal                                | How                                                                                                                                                                                 |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Find **PSLH 1** or **PhySci**       | Search + aliases (`PhySci`, `HUM`, …)                                                                                                                                               |
+| Room schedule this sem              | Term filter + timetable                                                                                                                                                             |
+| Personal schedule route             | Build a plan in Planner → Map tools → Schedule → pick a day, route stops                                                                                                            |
+| Browse all classes                  | Status bar → Browse classes; search by course code                                                                                                                                  |
+| Section with no room yet            | "No assigned room" rows hint the offering department and where the course usually meets (#846)                                                                                      |
+| Plan your classes                   | Planner view to build a draft schedule                                                                                                                                              |
+| What do I have today                | Today view (`/today`): your plan's classes for today, tomorrow, and the rest of the week; one tap routes the day on the map with total walking time and distance (`/today?route=1`) |
+| Course Planner explainer            | [Four-panel, screenshot-ready guide](https://room-tba.uplb.tools/pubmat/course-planner/)                                                                                            |
+| Final exam time & room              | Search course code → finals panel; room panel during finals week                                                                                                                    |
+| Academic calendar                   | [/calendar](https://room-tba.uplb.tools/calendar) — term windows on a year timeline; also via the term picker                                                                       |
+| Building location                   | Map, pins, directions, Google Maps                                                                                                                                                  |
+| Compare dorm listings               | Verified dorms link to their Kubo listing when available                                                                                                                            |
+| Landmarks, services, orgs & offices | Map filters and the App menu, distinct map pins, and shareable detail links                                                                                                         |
+| Offline / bad signal                | PWA + local cache; tiles if already loaded                                                                                                                                          |
+| Campus events                       | Events on map with routes                                                                                                                                                           |
+| Jeepney routes                      | Route overlays                                                                                                                                                                      |
+| Walking time from a point           | Map tools → Travel time; tap the map, paths color by minutes                                                                                                                        |
+| Measure a route                     | Map tools → Measure route; drop waypoints, get walk / cycle / car times                                                                                                             |
+| 3D view                             | Buildings + Makiling terrain (online)                                                                                                                                               |
+| Satellite imagery                   | Map tools → View → Satellite; choose locally changed historical imagery back to 2015 when online                                                                                    |
+| Common questions                    | [Student FAQ](https://room-tba.uplb.tools/faq) (3D models, data sources, offline)                                                                                                   |
+| Tell us something is wrong          | Settings → Feedback; free text, optional contact, or reach the team on Messenger / Discord                                                                                          |
+| Understand section names            | Wiki guide to the A–H / S–Z class time blocks                                                                                                                                       |
+| Find emergency contacts             | Menu → Emergency hotlines; bundled for offline use                                                                                                                                  |
+| Check dorm curfew rules             | UP-managed dorm details → Curfew & permits                                                                                                                                          |
 
 <details>
 <summary><strong>Editor / contributor mode</strong> (password from the team)</summary>
 
-| Power | Where |
-| -------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| Move building & dorm pins | Map edit mode (pencil) |
-| Add or correct landmarks, services, organizations, offices & units | **Add something to the map** or the side-panel editor; pick the map pin |
-| Fix room/building/college copy | Side panel → Edit |
-| Suggest edits without publishing | **Suggest an edit** → admin review queue |
-| Upload event posters | Event editor + R2 image upload (when configured) |
-| Manage public credit | Account settings → optional HTTPS avatar/profile link; uncheck credits to opt out |
-| Undo a pin drag | Toolbar undo/redo (session); durable history tracked in [#202](https://github.com/uplbtools/room-tba/issues/202) |
+| Power                                                              | Where                                                                                                            |
+| ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| Move building & dorm pins                                          | Map edit mode (pencil)                                                                                           |
+| Add or correct landmarks, services, organizations, offices & units | **Add something to the map** or the side-panel editor; pick the map pin                                          |
+| Fix room/building/college copy                                     | Side panel → Edit                                                                                                |
+| Suggest edits without publishing                                   | **Suggest an edit** → admin review queue                                                                         |
+| Upload event posters                                               | Event editor + R2 image upload (when configured)                                                                 |
+| Manage public credit                                               | Account settings → optional HTTPS avatar/profile link; uncheck credits to opt out                                |
+| Undo a pin drag                                                    | Toolbar undo/redo (session); durable history tracked in [#202](https://github.com/uplbtools/room-tba/issues/202) |
 
 Login: **`/?editor=login`** or the shield / status bar in the app. `/admin` URLs redirect back into the map.
 
@@ -179,32 +179,32 @@ Install the [Biome VS Code extension](https://marketplace.visualstudio.com/items
 
 ### Commands worth knowing
 
-| Command | Does what |
-| --- | --- |
-| `bun dev` | Dev server |
-| `bun run build` | Production build (**needs** `DATABASE_URL`; entity SEO pages render on first request via Vercel ISR, not at build) |
-| `bun test src/lib src/constants` | Unit + store tests (no DB required) |
-| `bun run test:components` | Vitest component/layout tests |
-| `bun run test:integration` | API + DB integration (E2E DB; see `docs/testing.md`) |
-| `bun run e2e` | Playwright blocking suite (uses `serve:e2e`: node adapter build + preview) |
-| `bun run e2e:advisory` | Playwright advisory (non-blocking in CI) |
-| `bun run lint` | Biome check (format + lint) |
-| `bun run lint:fix` | Biome check with auto-fixes |
-| `bun run format` | Biome format write |
-| `bunx drizzle-kit studio` | Browse/edit Postgres visually |
-| `bun run seed:aliases` | Seed building aliases from `public/room_info.json` |
-| `bun scripts/build-walk-graph.ts <graphml>` | Rebuild `src/generated/walk-graph.json` from an osmnx GraphML export (travel-time tools) |
-| `bun run seed:deep-research` | Fill-only data-gap seed from the 2026-07 research report (`DATABASE_URL`; `--dry-run` supported) |
-| `bun run generate:pglite-schema` | Regenerate the offline PGlite init SQL from `drizzle/schema.ts` |
-| `bun run import:osa-orgs` | Add the current public OSA organization directory (`DATABASE_URL`; safe to rerun) |
-| `bun run import:campus-offices` | Add missing campus offices and units (`DATABASE_URL`; safe to rerun) |
-| `bun run import:amis-classes` | Upsert AMIS classes (`docs/amis-com-refresh-runbook.md`) |
-| `bun run backfill:acad-orgs` | Rerun the AMIS import over the 9 cached term JSONs to fill `classes.acad_group`/`acad_org` (#846) |
-| `bun run import:final-exams` | Import OUR finals JSON into Postgres (`DATABASE_URL`; see `docs/final-exams-data-source.md`) |
-| `bun run audit:campus-data` | Read-only sweep for wrong pins, scattered tenants, missing building links and orphan rooms (`PROD_DATABASE_URL`; writes nothing) |
-| `bun run apply:campus-audit-links -- --prod --apply` | Apply the verified organization-to-building links from the campus audit, with `editor_history` records |
-| `bun run record:bulk-history` | Record `editor_history` rows for a maintenance/bulk data operation (`DATABASE_URL`; dry run unless `--apply`; see `docs/bulk-data-history.md`) |
-| `bun run backfill:bulk-history` | One-off: backfill history for the 2026-08-03/04 direct-database corrections (`DATABASE_URL`; dry run unless `--apply`) |
+| Command                                              | Does what                                                                                                                                      |
+| ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bun dev`                                            | Dev server                                                                                                                                     |
+| `bun run build`                                      | Production build (**needs** `DATABASE_URL`; entity SEO pages render on first request via Vercel ISR, not at build)                             |
+| `bun test src/lib src/constants`                     | Unit + store tests (no DB required)                                                                                                            |
+| `bun run test:components`                            | Vitest component/layout tests                                                                                                                  |
+| `bun run test:integration`                           | API + DB integration (E2E DB; see `docs/testing.md`)                                                                                           |
+| `bun run e2e`                                        | Playwright blocking suite (uses `serve:e2e`: node adapter build + preview)                                                                     |
+| `bun run e2e:advisory`                               | Playwright advisory (non-blocking in CI)                                                                                                       |
+| `bun run lint`                                       | Biome check (format + lint)                                                                                                                    |
+| `bun run lint:fix`                                   | Biome check with auto-fixes                                                                                                                    |
+| `bun run format`                                     | Biome format write                                                                                                                             |
+| `bunx drizzle-kit studio`                            | Browse/edit Postgres visually                                                                                                                  |
+| `bun run seed:aliases`                               | Seed building aliases from `public/room_info.json`                                                                                             |
+| `bun scripts/build-walk-graph.ts <graphml>`          | Rebuild `src/generated/walk-graph.json` from an osmnx GraphML export (travel-time tools)                                                       |
+| `bun run seed:deep-research`                         | Fill-only data-gap seed from the 2026-07 research report (`DATABASE_URL`; `--dry-run` supported)                                               |
+| `bun run generate:pglite-schema`                     | Regenerate the offline PGlite init SQL from `drizzle/schema.ts`                                                                                |
+| `bun run import:osa-orgs`                            | Add the current public OSA organization directory (`DATABASE_URL`; safe to rerun)                                                              |
+| `bun run import:campus-offices`                      | Add missing campus offices and units (`DATABASE_URL`; safe to rerun)                                                                           |
+| `bun run import:amis-classes`                        | Upsert AMIS classes (`docs/amis-com-refresh-runbook.md`)                                                                                       |
+| `bun run backfill:acad-orgs`                         | Rerun the AMIS import over the 9 cached term JSONs to fill `classes.acad_group`/`acad_org` (#846)                                              |
+| `bun run import:final-exams`                         | Import OUR finals JSON into Postgres (`DATABASE_URL`; see `docs/final-exams-data-source.md`)                                                   |
+| `bun run audit:campus-data`                          | Read-only sweep for wrong pins, scattered tenants, missing building links and orphan rooms (`PROD_DATABASE_URL`; writes nothing)               |
+| `bun run apply:campus-audit-links -- --prod --apply` | Apply the verified organization-to-building links from the campus audit, with `editor_history` records                                         |
+| `bun run record:bulk-history`                        | Record `editor_history` rows for a maintenance/bulk data operation (`DATABASE_URL`; dry run unless `--apply`; see `docs/bulk-data-history.md`) |
+| `bun run backfill:bulk-history`                      | One-off: backfill history for the 2026-08-03/04 direct-database corrections (`DATABASE_URL`; dry run unless `--apply`)                         |
 
 Legacy **`data/info.db`** SQLite is only for old seed/export scripts (`bun:sqlite`, not runtime). Production uses Supabase Postgres via `DATABASE_URL`. Archived SQLite migrations live in `drizzle-migrations/`: do not edit; active schema is `drizzle/`.
 
@@ -227,7 +227,7 @@ flowchart TB
   src --> lib["lib/ stores, services, PGlite sync"]
 ```
 
-Deep editor QA: [`docs/editor-foundation-test-plan.md`](docs/editor-foundation-test-plan.md) 
+Deep editor QA: [`docs/editor-foundation-test-plan.md`](docs/editor-foundation-test-plan.md)
 PR checklist: [`docs/agentic-qa-process.md`](docs/agentic-qa-process.md)
 
 ---
@@ -256,18 +256,22 @@ Dry run: `bun run release:dry`
 
 ## Credits
 
-**Maintainer:** [Simonee Ezekiel Mariquit](https://stimmie.dev)
+**Founder and lead:** [Simonee Ezekiel Mariquit](https://stimmie.dev)
 
-**Built with help from:**
+**Core team**
 
-| Person | Helped with |
-| ----------------------- | -------------------------------------- |
-| Ken Ramiscal | UI, offline support, map |
-| Kalinaw Lukas Aom Bebis | UI, bug fixes, map |
-| Niño Anthony Marmeto | Electrical Engineering building info |
-| Rosh Almario | Institute of Chemistry room directions |
-| Eunice Almeyda | Logo |
-| Mary Gwyneth Telmosa | UI design |
+| Person                                            | Works on                                 |
+| ------------------------------------------------- | ---------------------------------------- |
+| [Ken Ramiscal](https://kendan.dev)                | Offline support, map, interface          |
+| Eunice Almeyda                                    | Directions, map chrome, mobile interface |
+| [Simeon Ricalde](https://meonnn.github.io/)       | Publicity and outreach                   |
+| [Kalinaw Lukas Aom Bebis](https://lukasbebis.com) | Interface, map, bug fixes                |
+
+**Design:** [Rovic Villaralvo](https://rovicdesign.framer.website/) · Mary Gwyneth Telmosa (interface design)
+
+**Also contributed:** Niño Anthony Marmeto (Electrical Engineering building info) · Rosh Almario (Institute of Chemistry room directions) · everyone on the [contributors graph](https://github.com/uplbtools/room-tba/graphs/contributors)
+
+Team page: [uplb.tools/people](https://www.uplb.tools/people) · Press kit: [uplb.tools/press](https://www.uplb.tools/press)
 
 Org: [uplbtools](https://github.com/uplbtools) · Campus tool, not an official UPLB product.
 
@@ -296,12 +300,12 @@ MIT lets you fork this and run it for a different school. This is not a "swap th
 
 Community forks, maintained by their own campuses:
 
-| Campus | Fork |
-| --- | --- |
-| UP Visayas | [andrianllmm/upv-room-tba](https://github.com/andrianllmm/upv-room-tba) |
-| UP Baguio | [UPB-Tools/room-tba](https://github.com/UPB-Tools/room-tba) |
+| Campus                             | Fork                                                                                                                                  |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| UP Visayas                         | [andrianllmm/upv-room-tba](https://github.com/andrianllmm/upv-room-tba)                                                               |
+| UP Baguio                          | [UPB-Tools/room-tba](https://github.com/UPB-Tools/room-tba)                                                                           |
 | Bulacan State University (Malolos) | [bulsutools/room-tba](https://github.com/bulsutools/room-tba), live at [bulsu-room-tba.vercel.app](https://bulsu-room-tba.vercel.app) |
-| UP Diliman | [uplbtools/room-tba-upd](https://github.com/uplbtools/room-tba-upd) (our own port, in progress) |
+| UP Diliman                         | [uplbtools/room-tba-upd](https://github.com/uplbtools/room-tba-upd) (our own port, in progress)                                       |
 
 Full guide with every file path and the painful parts: **[Fork this for your campus](https://room-tba.uplb.tools/wiki/fork-for-your-campus)** in the wiki. For the config file, start with the **[fork wizard](https://room-tba.uplb.tools/fork)** — point a map at your campus and it generates `src/campus.config.ts` plus a Vercel deploy link.
 
@@ -311,14 +315,14 @@ Start with `bun run fork:init` — it asks for your campus name, URL, map center
 
 The short version of what you replace:
 
-| File | What to change |
-| --- | --- |
-| `src/campus.config.ts` | **The single config file** (`bun run fork:init` writes it). Site name, URL, title, description, map center/bounds/camera, terrain (`campusTerrain.enabled` off = flat map), transit overlay (`campusTransit.enabled` + menu label), E2E fixture coordinates, community links. The files below import from here. |
-| `public/room_info.json` | UPLB building seed → your buildings |
-| `src/constants/jeepney-routes.ts` + geometries | Your transit routes/stops, or set `campusTransit.enabled: false` to hide the overlay everywhere |
-| `src/generated/walk-graph.json` | UPLB path network (travel-time tools). Rebuild from your campus's OSM extract: `bun scripts/build-walk-graph.ts <your-osmnx-export.graphml>`; speeds in `src/constants/travel-modes.ts`. |
-| `scripts/import-amis-classes.ts` and friends | UPLB data sources (AMIS, OUR finals, OSA). Use `bun run import:classes-generic` with your registrar's export instead ([guide](docs/fork-data-guide.md)). |
-| Supabase DB contents | Every row is UPLB. Schema stays; data goes. |
+| File                                           | What to change                                                                                                                                                                                                                                                                                                  |
+| ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/campus.config.ts`                         | **The single config file** (`bun run fork:init` writes it). Site name, URL, title, description, map center/bounds/camera, terrain (`campusTerrain.enabled` off = flat map), transit overlay (`campusTransit.enabled` + menu label), E2E fixture coordinates, community links. The files below import from here. |
+| `public/room_info.json`                        | UPLB building seed → your buildings                                                                                                                                                                                                                                                                             |
+| `src/constants/jeepney-routes.ts` + geometries | Your transit routes/stops, or set `campusTransit.enabled: false` to hide the overlay everywhere                                                                                                                                                                                                                 |
+| `src/generated/walk-graph.json`                | UPLB path network (travel-time tools). Rebuild from your campus's OSM extract: `bun scripts/build-walk-graph.ts <your-osmnx-export.graphml>`; speeds in `src/constants/travel-modes.ts`.                                                                                                                        |
+| `scripts/import-amis-classes.ts` and friends   | UPLB data sources (AMIS, OUR finals, OSA). Use `bun run import:classes-generic` with your registrar's export instead ([guide](docs/fork-data-guide.md)).                                                                                                                                                        |
+| Supabase DB contents                           | Every row is UPLB. Schema stays; data goes.                                                                                                                                                                                                                                                                     |
 
 The hard part is class schedules. Room TBA pulls from AMIS, which is UPLB's system. You do not have AMIS — flatten whatever your registrar gives you into the generic importer's CSV/JSON shape ([docs/fork-data-guide.md](docs/fork-data-guide.md)) and rerun it each term. `data/sample-campus/classes.csv` is the worked example.
 
@@ -328,12 +332,12 @@ After you think you've replaced everything, run `bun run fork:check` — it scan
 
 ## License
 
-| Layer | License |
-| --- | --- |
-| Application code | [MIT](LICENSE) |
-| Community campus map data (buildings, rooms, dorms, orgs, pins, aliases) | [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/) |
-| OpenStreetMap basemap / footprints | [ODbL](https://www.openstreetmap.org/copyright) (+ [MapTiler](https://www.maptiler.com/copyright/) for tiles) |
-| AMIS/CRS, OUR, OSA imports | Not offered under an open bulk license |
+| Layer                                                                    | License                                                                                                       |
+| ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| Application code                                                         | [MIT](LICENSE)                                                                                                |
+| Community campus map data (buildings, rooms, dorms, orgs, pins, aliases) | [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/)                                                     |
+| OpenStreetMap basemap / footprints                                       | [ODbL](https://www.openstreetmap.org/copyright) (+ [MapTiler](https://www.maptiler.com/copyright/) for tiles) |
+| AMIS/CRS, OUR, OSA imports                                               | Not offered under an open bulk license                                                                        |
 
 Use the code, fork it, teach with it. If you deploy a fork for another campus, change the data, not just the logo. See the [fork guide](#fork-this-for-your-campus) above. Student-facing summary: [FAQ — Can I reuse Room TBA data?](https://room-tba.uplb.tools/faq#data-license).
 

--- a/src/constants/contributors.ts
+++ b/src/constants/contributors.ts
@@ -13,10 +13,15 @@ export const githubProfileOverrides: Record<
     href: "https://kendan.dev",
   },
   klnwlks: { name: "Kalinaw Lukas Aom Bebis", href: "https://lukasbebis.com" },
+  unisA02: { name: "Eunice Almeyda" },
+  meonnn: { name: "Simeon Ricalde", href: "https://meonnn.github.io/" },
 };
 
 /** Design credits for people who did not appear in GitHub commit history. */
-export const designers: ContributorInfo[] = [{ name: "Gwy Telmosa" }];
+export const designers: ContributorInfo[] = [
+  { name: "Rovic Villaralvo", href: "https://rovicdesign.framer.website/" },
+  { name: "Gwy Telmosa" },
+];
 
 export const contributors: ContributorInfo[] = [
   { name: "Niño Anthony Marmeto" },


### PR DESCRIPTION
## What

- **README `## Credits`**: replaces "Maintainer" + "Built with help from" with the same roster used on uplb.tools/people and /press: founder and lead, core team (Ken, Eunice, Simeon, Lukas), design (Rovic, Gwy), also contributed (Niño, Rosh, contributors graph).
- **`src/constants/contributors.ts`**: adds `unisA02` (Eunice) and `meonnn` (Simeon) display overrides so the landing modal stops showing raw logins; adds Rovic Villaralvo to `designers`.

## Why

Eunice was credited as "Logo". Her commits are the multi-modal directions feature and most of the mobile map chrome. Rovic was absent from in-app design credits. Three surfaces (README, landing modal, uplb.tools) said three different things.

## Verify

- `bunx biome check src/constants/contributors.ts` clean
- README re-run through prettier
- Landing modal: open the app fresh, About section should show Eunice and Simeon by name and Rovic under design

https://claude.ai/code/session_01QPNhdfBTiV5z8ji7333hug