### PR TITLE
fix(planner): link compact recit sections like WX1R to their lecture

### DIFF
--- a/src/lib/class-offering-groups.test.ts
+++ b/src/lib/class-offering-groups.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import {
   groupClassesByOffering,
+  parentLectureCandidates,
   parentLectureSection,
 } from "./class-offering-groups.js";
 import type { ClassMapValue } from "@lib/types";
@@ -45,6 +46,15 @@ describe("parentLectureSection", () => {
     expect(parentLectureSection(row({ section: "ST2R", type: "RCT" }))).toBe(
       "ST2",
     );
+  });
+
+  test("offers the digit-stripped lecture as a second candidate (#799)", () => {
+    expect(
+      parentLectureCandidates(row({ section: "WX1R", type: "RCT" })),
+    ).toEqual(["WX1", "WX"]);
+    expect(
+      parentLectureCandidates(row({ section: "G-1L", type: "LAB" })),
+    ).toEqual(["G"]);
   });
 
   test("returns null for standalone lecture/seminar sections", () => {
@@ -125,6 +135,24 @@ describe("groupClassesByOffering", () => {
     expect(ab2r?.sections.map((s) => `${s.section}/${s.type}`)).toEqual([
       "AB2/LEC",
       "AB2R/RCT",
+    ]);
+  });
+
+  test("links STAT 135 compact recits (WX1R) to the single lecture WX (#799)", () => {
+    const groups = groupClassesByOffering([
+      row({ id: 1, courseCode: "STAT 135", section: "WX", type: "LEC" }),
+      row({ id: 2, courseCode: "STAT 135", section: "WX1R", type: "RCT" }),
+      row({ id: 3, courseCode: "STAT 135", section: "WX2R", type: "RCT" }),
+    ]);
+
+    expect(groups.map((group) => group.section).sort()).toEqual([
+      "WX1R",
+      "WX2R",
+    ]);
+    const wx1r = groups.find((g) => g.section === "WX1R");
+    expect(wx1r?.sections.map((s) => `${s.section}/${s.type}`)).toEqual([
+      "WX/LEC",
+      "WX1R/RCT",
     ]);
   });
 });

--- a/src/lib/class-offering-groups.ts
+++ b/src/lib/class-offering-groups.ts
@@ -44,6 +44,31 @@ export function offeringGroupKey(
   return `${courseCode}::${section}`;
 }
 
+/**
+ * Lecture sections a child section could belong to, most specific first.
+ * "ST2R" is normally the recit of lecture "ST2", but STAT 135 names its recits
+ * "WX1R" to "WX6R" under one lecture "WX", so the digit-stripped form is a
+ * second candidate. Callers keep the first one that actually exists (#799).
+ */
+export function parentLectureCandidates(row: ClassMapValue): string[] {
+  const first = parentLectureSection(row);
+  if (!first) return [];
+  const stripped = first.replace(/\d+$/, "");
+  return stripped && stripped !== first ? [first, stripped] : [first];
+}
+
+/** First parent candidate present in `known` (section names), else null. */
+export function resolveParentLecture(
+  row: ClassMapValue,
+  known: Iterable<string>,
+): string | null {
+  const have = new Set([...known].map((s) => s.trim().toUpperCase()));
+  for (const candidate of parentLectureCandidates(row)) {
+    if (have.has(candidate)) return candidate;
+  }
+  return null;
+}
+
 /** Group LEC/LAB/SEM rows that share course code + section (#301). */
 export function groupClassesByOffering(
   classes: ClassMapValue[],
@@ -84,10 +109,16 @@ export function groupClassesByOffering(
   for (const group of groups.values()) {
     const linkedLectures = new Map<number, ClassMapValue>();
     for (const row of group.sections) {
-      const parentSection = parentLectureSection(row);
-      const parentKey = offeringGroupKey(row.courseCode, parentSection);
-      const parent = parentKey ? groups.get(parentKey) : null;
-      if (!parent || parent === group) continue;
+      let parent: ClassOfferingGroup | null = null;
+      for (const candidate of parentLectureCandidates(row)) {
+        const key = offeringGroupKey(row.courseCode, candidate);
+        const found = key ? groups.get(key) : null;
+        if (found && found !== group) {
+          parent = found;
+          break;
+        }
+      }
+      if (!parent) continue;
       for (const parentRow of parent.sections) {
         if (classType(parentRow) === "LEC") {
           linkedLectures.set(parentRow.id, parentRow);

--- a/src/lib/stores/planner-store.svelte.ts
+++ b/src/lib/stores/planner-store.svelte.ts
@@ -1,6 +1,7 @@
 import {
   offeringGroupKey,
   parentLectureSection,
+  resolveParentLecture,
 } from "../class-offering-groups.js";
 import { findConflicts } from "../planner/conflicts.js";
 import {
@@ -121,7 +122,15 @@ export class PlannerStore {
     // component removes the whole unit. Resolve each section to its lecture
     // (itself if it is the lecture, else the parent encoded in a child section
     // like "C-4L" -> "C") and drop everything in that unit for the course.
-    const unitOf = (s: string) => parentLectureSection({ section: s }) ?? s;
+    // Resolve against the sections actually in the plan so a compact recit
+    // like "WX1R" finds lecture "WX" rather than a nonexistent "WX1" (#799).
+    const planned = plan.sections
+      .filter((s) => s.courseCode === courseCode)
+      .map((s) => s.section);
+    const unitOf = (s: string) =>
+      resolveParentLecture({ section: s }, planned) ??
+      parentLectureSection({ section: s }) ??
+      s;
     const targetUnit = unitOf(section);
     plan.sections = plan.sections.filter(
       (s) => s.courseCode !== courseCode || unitOf(s.section) !== targetUnit,

--- a/src/lib/stores/planner.store.test.ts
+++ b/src/lib/stores/planner.store.test.ts
@@ -70,6 +70,26 @@ describe("PlannerStore", () => {
     expect(store.activePlan?.sections).toEqual([]);
   });
 
+  test("removing a compact recit (WX1R) also removes lecture WX (#799)", () => {
+    const store = makeStore();
+    store.addOffering([
+      row({ id: 1, courseCode: "STAT 135", section: "WX", type: "LEC" }),
+      row({ id: 2, courseCode: "STAT 135", section: "WX1R", type: "RCT" }),
+    ]);
+    store.removeOffering("STAT 135", "WX1R");
+    expect(store.activePlan?.sections).toEqual([]);
+  });
+
+  test("removing lecture WX also removes its compact recit (#799)", () => {
+    const store = makeStore();
+    store.addOffering([
+      row({ id: 1, courseCode: "STAT 135", section: "WX", type: "LEC" }),
+      row({ id: 2, courseCode: "STAT 135", section: "WX1R", type: "RCT" }),
+    ]);
+    store.removeOffering("STAT 135", "WX");
+    expect(store.activePlan?.sections).toEqual([]);
+  });
+
   test("refreshActivePlan does NOT stale a section whose course was not fetched", () => {
     const store = makeStore();
     store.addOffering([row({ id: 1, section: "AB", type: "LEC" })]);


### PR DESCRIPTION
## What

STAT 135's recitations are named `WX1R` to `WX6R` under one lecture `WX` (checked against the current term, 1261). `parentLectureSection("WX1R")` returned `WX1`, which is not a section, so the recit never linked to its lecture. In the planner that meant picking a recit called `replaceCourse` with a recit-only offering and dropped the lecture, which is #799.

- `parentLectureCandidates` returns the existing result plus the digit-stripped form, most specific first (`["WX1", "WX"]`, `["ST2", "ST"]`).
- `groupClassesByOffering` and `removeOffering` take the first candidate that actually exists, so `AB2R` still resolves to `AB2` (AGRI 61 test unchanged) and `WX1R` now resolves to `WX`.

## Verify

- `bun test src/lib/class-offering-groups.test.ts`: 9 pass (2 new).
- `bunx vitest run src/lib/stores/planner.store.test.ts`: 22 pass (2 new, one per removal direction).
- biome clean on the four files.

Closes #799

https://claude.ai/code/session_01JLiF1MHjFFT7cQ67nhp14u