### PR TITLE
fix(map): serve label glyphs from MapTiler, the old host is dead

### DIFF
--- a/public/liberty-customized.json
+++ b/public/liberty-customized.json
@@ -21,7 +21,7 @@
     }
   },
   "sprite": "https://maputnik.github.io/osm-liberty/sprites/osm-liberty",
-  "glyphs": "https://orangemug.github.io/font-glyphs/glyphs/{fontstack}/{range}.pbf",
+  "glyphs": "https://api.maptiler.com/fonts/{fontstack}/{range}.pbf?key=__MAPTILER_KEY__",
   "layers": [
     {
       "id": "background",


### PR DESCRIPTION
One line in `public/liberty-customized.json`. The glyph host `orangemug.github.io/font-glyphs` returns 404 for every range, so labels rendered only when MapLibre's local fallback happened to cover the characters. MapTiler serves `Roboto Regular`, `Roboto Medium`, and `Roboto Condensed Italic` (all 200 with our key, checked 2026-09-11), and `injectMaptilerKey` already replaces `__MAPTILER_KEY__` throughout the style, so no code change.

Verify on the preview: open the map, console should have no `font-glyphs` 404s and building labels should render at every zoom.

Closes #1169

https://claude.ai/code/session_01JLiF1MHjFFT7cQ67nhp14u